### PR TITLE
install: Add initial version

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+# Set desired version to be installed
+VERSION="${VERSION:-master}"
+REMOTE="${REMOTE:-https://raw.githubusercontent.com/bluerobotics/companion-docker}"
+REMOTE="$REMOTE/$VERSION"
+
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+# Check if the script is running in ARM architecture
+[[ "$(uname -m)" != "arm"* ]] && echo "Companion only supports ARM computers."
+
+# Check if the script is running as root
+[[ $EUID != 0 ]] && echo "Script must run as root."  && exit 1
+
+# Check for docker and install it if not found
+echo "Checking for docker."
+docker --version || curl -fsSL https://get.docker.com | sh && systemctl enable docker
+
+# Stop and remove all docker if NO_CLEAN is not defined
+test $NO_CLEAN || (
+    # Check if there is any docker installed
+    [[ $(docker ps -a -q) ]] && (
+        echo "Stopping running dockers."
+        docker stop $(docker ps -a -q)
+
+        echo "Removing dockers."
+        docker rm $(docker ps -a -q)
+    ) || true
+)
+
+# Start installing necessary files and system configuration
+echo "Going to install companion-docker version ${VERSION}."
+
+echo "Downloading and installing udev rules."
+curl -fsSL $REMOTE/$VERSION/udev/100.autopilot.rules -o /etc/udev/rules.d/100.autopilot.rules
+
+echo "Downloading companion-core"
+COMPANION_CORE="bluerobotics/companion-core:master" # We don't have others tags for now
+docker pull $COMPANION_CORE
+docker create \
+    --restart unless-stopped \
+    --name companion-core \
+    --privileged \
+    --network host \
+    -v /dev:/dev \
+    -v /tmp/wpa_playground:/tmp/wpa_playground \
+    -v /var/run/wpa_supplicant/wlan0:/var/run/wpa_supplicant/wlan0 \
+    $COMPANION_CORE
+# Start companion-core for the first time to allow docker to restart it after reboot
+docker start companion-core
+
+echo "Installation finished successfully."
+echo "System will reboot in 10 seconds."
+sleep 10 && reboot

--- a/install/udev/100.autopilot.rules
+++ b/install/udev/100.autopilot.rules
@@ -1,0 +1,2 @@
+SUBSYSTEM=="tty", ATTRS{manufacturer}=="3D Robotics", ATTRS{product}=="PX4 FMU v2.x", SYMLINK+="autopilot"
+SUBSYSTEM=="tty", ATTRS{manufacturer}=="ArduPilot", SYMLINK+="autopilot"


### PR DESCRIPTION
Configures a fresh image with companion-docker.
After it reboots, companion-docker will star automatically. 

`Curl` is necessary to run this script.
The following lines need to run as **root**.
How to test (if the repository is public):
```sh
# These variables are not necessary since the default value now is master
# and my remote is necessary since it's not merged.
export VERSION=install
export REMOTE=https://raw.githubusercontent.com/patrickelectric/companion-docker
curl -fsSL https://raw.githubusercontent.com/patrickelectric/companion-docker/install/install/install.sh | sh
```
Changes are necessary for non public repositories. 

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>