### PR TITLE
Bootstrap: change base image to debian:buster-slim (same as core)

### DIFF
--- a/bootstrap/Dockerfile
+++ b/bootstrap/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:buster
+FROM debian:buster-slim
+RUN apt update && apt install -y python3 python3-setuptools python3-pip --no-install-recommends
 COPY startup.json.default bootstrap/ /bootstrap/
 COPY main.py /
 RUN python3 bootstrap/setup.py install


### PR DESCRIPTION
![Screenshot from 2020-09-21 13-29-27](https://user-images.githubusercontent.com/4013804/93794580-a10dcf80-fc0e-11ea-908e-8749e80b6c56.png)

close #48 