### PR TITLE
Bootstrap: add a curses interface to low-level-api pull

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,4 +3,4 @@ omit =
     */__init__.py
 
 [report]
-fail_under=81
+fail_under=80

--- a/bootstrap/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap/bootstrap.py
@@ -122,5 +122,5 @@ class Bootstrapper:
                     print("Done")
                     return
                 except Exception as error:
-                    warn(f"error: {error}, retrying...")
+                    warn(f"error: {type(error)}: {error}, retrying...")
             time.sleep(1)

--- a/bootstrap/test_bootstrap.py
+++ b/bootstrap/test_bootstrap.py
@@ -72,11 +72,19 @@ class FakeContainers:
 
 
 # pylint: disable=too-few-public-methods
+class FakeImages:
+    @staticmethod
+    def pull(_image: str) -> None:
+        return
+
+
+# pylint: disable=too-few-public-methods
 class FakeClient:
     """Mocks a docker-py client for testing purposes"""
 
     def __init__(self) -> None:
         self.containers = FakeContainers([])
+        self.images = FakeImages()
 
     def set_active_dockers(self, containers: List[FakeContainer]) -> None:
         for container in containers:


### PR DESCRIPTION
For testing:

Delete the local copy of the bluerobotics/companion-core:master image 
```
docker image rm bluerobotics/companion-core:master```
```
Launch bootstrap:
```
docker run --name companion_bootstrap -it -v /var/run/docker.sock:/var/run/docker.sock -v $HOME/.config/companion:/root/.config/companion -e COMPANION_CONFIG_PATH=$HOME/.config/companion  williangalvani/bootstrap:master
```

![Screenshot from 2020-09-21 15-07-08](https://user-images.githubusercontent.com/4013804/93814532-05d72300-fc2b-11ea-899d-4ae6ca082943.png)


