### PR TITLE
core: start-companion-core: Add h264parse

### DIFF
--- a/core/start-companion-core
+++ b/core/start-companion-core
@@ -7,7 +7,7 @@ SERVICES=(
     'cable_guy',"$SERVICES_PATH/cable_guy/main.py"
     'wifi',"$SERVICES_PATH/wifi/main.py"
     'autopilot',"$SERVICES_PATH/ardupilot_manager/main.py"
-    'video',"gst-rtsp-launch '( v4l2src device=/dev/video2 ! video/x-h264, width=1920, height=1080, framerate=30/1 ! rtph264pay name=pay0 pt=96 )'"
+    'video',"gst-rtsp-launch '( v4l2src device=/dev/video2 ! video/x-h264, width=1920, height=1080, framerate=30/1 ! h264parse ! rtph264pay name=pay0 pt=96 )'"
 )
 
 tmux start-server


### PR DESCRIPTION
Add missing h264parser, decrease the cpu usage in 50%

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>