### PR TITLE
Bootstrap: Fix config file path

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -24,7 +24,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install wheel # wheel need to be installed before mavproxy
         pip install mavproxy
-        pip install pyfakefs pytest-cov pylint mypy isort black
+        pip install pyfakefs pytest-cov pytest-timeout pylint mypy isort black
         find . -type f -name "setup.py" | xargs --max-lines=1 --replace=% python % install --user
     -
       name: Run tests

--- a/bootstrap/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap/bootstrap.py
@@ -13,7 +13,8 @@ import docker
 class Bootstrapper:
 
     DEFAULT_FILE_PATH = pathlib.Path("/bootstrap/startup.json.default")
-    DOCKER_CONFIG_PATH = pathlib.Path("/root/.config/companion/startup.json")
+    DOCKER_CONFIG_PATH = pathlib.Path("/root/.config/companion/")
+    DOCKER_CONFIG_FILE_PATH = pathlib.Path(DOCKER_CONFIG_PATH, "startup.json")
     HOST_CONFIG_PATH = os.environ.get("COMPANION_CONFIG_PATH", None)
     CORE_CONTAINER_NAME = "companion_core"
 
@@ -27,7 +28,7 @@ class Bootstrapper:
     @staticmethod
     def overwrite_config_file_with_defaults() -> None:
         """Overwrites the config file with the default configuration"""
-        shutil.copy(Bootstrapper.DEFAULT_FILE_PATH, Bootstrapper.DOCKER_CONFIG_PATH)
+        shutil.copy(Bootstrapper.DEFAULT_FILE_PATH, Bootstrapper.DOCKER_CONFIG_FILE_PATH)
 
     @staticmethod
     def read_config_file() -> Dict[str, Any]:
@@ -40,7 +41,7 @@ class Bootstrapper:
         # Tries to open the current file
         config = {}
         try:
-            with open(Bootstrapper.DOCKER_CONFIG_PATH) as config_file:
+            with open(Bootstrapper.DOCKER_CONFIG_FILE_PATH) as config_file:
                 config = json.load(config_file)
                 assert "core" in config, "missing core entry in startup.json"
                 necessary_keys = ["image", "tag", "binds", "privileged", "network"]

--- a/bootstrap/test_bootstrap.py
+++ b/bootstrap/test_bootstrap.py
@@ -115,14 +115,14 @@ class BootstrapperTests(TestCase):  # type: ignore
         self.setUpPyfakefs()
 
     def test_start_core(self) -> None:
-        self.fs.create_file(Bootstrapper.DOCKER_CONFIG_PATH, contents=SAMPLE_JSON)
+        self.fs.create_file(Bootstrapper.DOCKER_CONFIG_FILE_PATH, contents=SAMPLE_JSON)
         fake_client = FakeClient()
         bootstrapper = Bootstrapper(fake_client, FakeLowLevelAPI())
         bootstrapper.start_core()
 
     def test_start_core_no_config(self) -> None:
         self.fs.create_file(Bootstrapper.DEFAULT_FILE_PATH, contents=SAMPLE_JSON)
-        self.fs.create_dir(Path(Bootstrapper.DOCKER_CONFIG_PATH).parent)
+        self.fs.create_dir(Path(Bootstrapper.DOCKER_CONFIG_PATH))
         fake_client = FakeClient()
         bootstrapper = Bootstrapper(fake_client, FakeLowLevelAPI())
         bootstrapper.start_core()
@@ -147,7 +147,7 @@ class BootstrapperTests(TestCase):  # type: ignore
         assert bootstrapper.core_is_running() is False
 
     def test_bootstrap_start(self) -> None:
-        self.fs.create_file(Bootstrapper.DOCKER_CONFIG_PATH, contents=SAMPLE_JSON)
+        self.fs.create_file(Bootstrapper.DOCKER_CONFIG_FILE_PATH, contents=SAMPLE_JSON)
         bootstrapper = Bootstrapper(FakeClient(), FakeLowLevelAPI())
         assert bootstrapper.core_is_running() is False
         bootstrapper.run()
@@ -155,7 +155,7 @@ class BootstrapperTests(TestCase):  # type: ignore
 
     def test_bootstrap_start_bad_json(self) -> None:
         self.fs.create_file(Bootstrapper.DEFAULT_FILE_PATH, contents=SAMPLE_JSON)
-        self.fs.create_file(Bootstrapper.DOCKER_CONFIG_PATH, contents=json.dumps({"potato": "bread"}))
+        self.fs.create_file(Bootstrapper.DOCKER_CONFIG_FILE_PATH, contents=json.dumps({"potato": "bread"}))
         bootstrapper = Bootstrapper(FakeClient(), FakeLowLevelAPI())
         bootstrapper.run()
         assert bootstrapper.core_is_running()

--- a/bootstrap/test_bootstrap.py
+++ b/bootstrap/test_bootstrap.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 from typing import Any, Dict, Generator, List
 
+import pytest
 from docker.errors import NotFound
 from pyfakefs.fake_filesystem_unittest import TestCase
 
@@ -114,12 +115,14 @@ class BootstrapperTests(TestCase):  # type: ignore
     def setUp(self) -> None:
         self.setUpPyfakefs()
 
+    @pytest.mark.timeout(10)
     def test_start_core(self) -> None:
         self.fs.create_file(Bootstrapper.DOCKER_CONFIG_FILE_PATH, contents=SAMPLE_JSON)
         fake_client = FakeClient()
         bootstrapper = Bootstrapper(fake_client, FakeLowLevelAPI())
         bootstrapper.start_core()
 
+    @pytest.mark.timeout(10)
     def test_start_core_no_config(self) -> None:
         self.fs.create_file(Bootstrapper.DEFAULT_FILE_PATH, contents=SAMPLE_JSON)
         self.fs.create_dir(Path(Bootstrapper.DOCKER_CONFIG_PATH))
@@ -128,6 +131,7 @@ class BootstrapperTests(TestCase):  # type: ignore
         bootstrapper.start_core()
 
     @staticmethod
+    @pytest.mark.timeout(10)
     def test_is_running() -> None:
         fake_client = FakeClient()
         bootstrapper = Bootstrapper(fake_client, FakeLowLevelAPI())
@@ -137,6 +141,7 @@ class BootstrapperTests(TestCase):  # type: ignore
         assert bootstrapper.core_is_running()
 
     @staticmethod
+    @pytest.mark.timeout(10)
     def test_remove_core() -> None:
         fake_client = FakeClient()
         bootstrapper = Bootstrapper(fake_client, FakeLowLevelAPI())
@@ -146,6 +151,7 @@ class BootstrapperTests(TestCase):  # type: ignore
         bootstrapper.remove_core()
         assert bootstrapper.core_is_running() is False
 
+    @pytest.mark.timeout(10)
     def test_bootstrap_start(self) -> None:
         self.fs.create_file(Bootstrapper.DOCKER_CONFIG_FILE_PATH, contents=SAMPLE_JSON)
         bootstrapper = Bootstrapper(FakeClient(), FakeLowLevelAPI())
@@ -153,6 +159,7 @@ class BootstrapperTests(TestCase):  # type: ignore
         bootstrapper.run()
         assert bootstrapper.core_is_running()
 
+    @pytest.mark.timeout(10)
     def test_bootstrap_start_bad_json(self) -> None:
         self.fs.create_file(Bootstrapper.DEFAULT_FILE_PATH, contents=SAMPLE_JSON)
         self.fs.create_file(Bootstrapper.DOCKER_CONFIG_FILE_PATH, contents=json.dumps({"potato": "bread"}))


### PR DESCRIPTION
It was erroneously trying to mount the startup.json file as a volume instead of the parent directory it is in. You cannot mount a file as a volume.

This makes docker mount the correct volume in line 57

for testing, use williangalvani/bootstrap:master in install.sh