### PR TITLE
Create Version Chooser

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install wheel # wheel need to be installed before mavproxy
         pip install mavproxy
-        pip install pyfakefs pytest-cov pytest-timeout pylint mypy isort black
+        pip install pyfakefs pytest-cov pytest-timeout pylint mypy isort black asyncmock
         find . -type f -name "setup.py" | xargs --max-lines=1 --replace=% python % install --user
 
         MAVLINK_ROUTER_PATH="/tmp/mavlink-router"

--- a/bootstrap/startup.json.default
+++ b/bootstrap/startup.json.default
@@ -21,6 +21,10 @@
             "/tmp/wpa_playground": {
                 "bind": "/tmp/wpa_playground",
                 "mode": "rw"
+            },
+            "/var/run/docker.sock": {
+                "bind": "/var/run/docker.sock",
+                "mode": "rw"
             }
         },
         "privileged": true

--- a/core/services/install-services.sh
+++ b/core/services/install-services.sh
@@ -27,6 +27,9 @@ cd /home/pi/services/ardupilot_manager/ && python3 setup.py install
 # Helper service
 cd /home/pi/services/helper/ && python3 setup.py install
 
+# Version Chooser service:
+cd /home/pi/services/versionchooser/ && python3 setup.py install
+
 apt -y remove ${BUILD_PACKAGES[*]}
 apt -y autoremove
 apt -y clean

--- a/core/services/versionchooser/main.py
+++ b/core/services/versionchooser/main.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+from typing import Any
+
+import connexion
+import docker
+from aiohttp import web
+from utils.chooser import STATIC_FOLDER, VersionChooser
+
+versionChooser = VersionChooser(docker.client.from_env())
+
+
+async def index(_request: web.Request) -> Any:
+    return versionChooser.index()
+
+
+async def get_version() -> Any:
+    return versionChooser.get_version()
+
+
+async def pull_version(request: web.Request) -> Any:
+    data = await request.json()
+    repository = data["repository"]
+    tag = data["tag"]
+    return await versionChooser.pull_version(request, repository, tag)
+
+
+async def set_version(request: web.Request) -> Any:
+    data = await request.json()
+    tag = data["tag"]
+    repository = data["repository"]
+    return await versionChooser.set_version(repository, tag)
+
+
+async def get_available_versions(repository: str, image: str) -> Any:
+    return await versionChooser.get_available_versions(f"{repository}/{image}")
+
+
+if __name__ == "__main__":
+    app = connexion.AioHttpApp(__name__, specification_dir="openapi/")
+    app.add_api(
+        "versionchooser.yaml", arguments={"title": "Companion Version Chooser"}, pass_context_arg_name="request"
+    )
+    app.app.router.add_static("/static/", path=str(STATIC_FOLDER))
+    app.app.router.add_route("GET", "/", index)
+    app.run(port=8081)

--- a/core/services/versionchooser/openapi/versionchooser.yaml
+++ b/core/services/versionchooser/openapi/versionchooser.yaml
@@ -1,0 +1,106 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Companion Version Chooser
+  license:
+    name: MIT
+servers:
+  - url: http://localhost:8081/v1.0
+
+paths:
+  /version/current:
+    get:
+      operationId: main.get_version
+      summary: Return the current running version of Companion
+      responses:
+        '200':
+          description: The current running version of Companion
+    post:
+      operationId: main.set_version
+      summary: Sets the current version of Companion to a new tag
+      responses:
+        '200':
+          description: Sucessfully set a new version
+        '400':
+          description: Attempted to set an unavailable version
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                repository:
+                  type: string
+                  example: bluerobotics/companion-core
+                tag:
+                  type: string
+                  example: master
+
+  /version/available/{repository}/{image}:
+    get:
+      operationId: main.get_available_versions
+      summary: Returns available versions, both locally and in dockerhub
+      parameters:
+        - in: path
+          name: repository
+          schema:
+            type: string
+          x-nullable: true
+          required: true
+        - name: image
+          in: path
+          schema:
+            type: string
+          required: true
+          example: companion-core
+      responses:
+        '200':
+          description: A list of versions available locally and on the remote(s)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  remote:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Version'
+                  local:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Version'
+
+  /version/pull/:
+    post:
+      operationId: main.pull_version
+      summary: Pulls a version from dockerhub
+
+      responses:
+        '200':
+          description: Sucessfully set a new version
+        '400':
+          description: Attempted to set an unavailable version
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                repository:
+                  type: string
+                  example: bluerobotics/companion-core
+                tag:
+                  type: string
+                  example: master
+
+components:
+  schemas:
+    Version:
+      type: object
+      properties:
+        image:
+          type: string
+          example: bluerobotics/companion-core
+        tag:
+          type: string
+          example: master

--- a/core/services/versionchooser/setup.py
+++ b/core/services/versionchooser/setup.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+import pathlib
+import ssl
+import urllib.request
+from warnings import warn
+
+from setuptools import setup
+
+ssl._create_default_https_context = ssl._create_unverified_context
+
+
+static_files = {
+    "js/axios.min.js": "https://cdnjs.cloudflare.com/ajax/libs/axios/0.19.2/axios.min.js",
+    "js/polyfill.min.js": "https://polyfill.io/v3/polyfill.min.js?features=es2015,IntersectionObserver",
+    "js/vue.js": "https://cdnjs.cloudflare.com/ajax/libs/vue/2.6.12/vue.js",
+    "js/timeago.js": "https://cdnjs.cloudflare.com/ajax/libs/timeago.js/2.0.2/timeago.min.js",
+    "js/metro.js": "https://cdnjs.cloudflare.com/ajax/libs/metro/4.4.3/js/metro.min.js",
+    "js/jquery.js": "https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js",
+    "css/metro-all.css": "https://cdnjs.cloudflare.com/ajax/libs/metro/4.4.3/css/metro-all.css",
+    "mif/metro.woff": "https://cdnjs.cloudflare.com/ajax/libs/metro/4.4.3/mif/metro.woff",
+    "mif/metro.ttf": "https://cdnjs.cloudflare.com/ajax/libs/metro/4.4.3/mif/metro.ttf",
+}
+
+current_folder = pathlib.Path(__file__).parent.absolute()
+static_folder = pathlib.Path.joinpath(current_folder, "static")
+
+for filename, url in static_files.items():
+    path = pathlib.Path.joinpath(static_folder, filename)
+    path.parent.mkdir(exist_ok=True)
+    try:
+        urllib.request.urlretrieve(url, path)
+    except Exception as error:
+        warn(f"unable to open url {url}, error {error}")
+
+setup(
+    name="versionchooser_service",
+    version="0.1.0",
+    description="Blue Robotics Ardusub Companion Version Chooser",
+    license="MIT",
+    install_requires=[
+        "aiohttp-jinja2 == 1.4.2",
+        "aiohttp == 3.7.3",
+        "connexion[swagger-ui, aiohttp] == 2.7.0",
+        "docker == 4.4.4",
+        "appdirs == 1.4.4",
+        "pytest-asyncio == 0.14.0",
+        "asyncmock == 0.4.2",
+        "werkzeug == 2.0.0rc4",
+        "attrs == 20.3.0",
+    ],
+)

--- a/core/services/versionchooser/static/index.html
+++ b/core/services/versionchooser/static/index.html
@@ -1,0 +1,256 @@
+<!DOCTYPE html>
+<html>
+
+
+  <head>
+    <title>Version Chooser</title>
+    <link rel="stylesheet" href="/static/css/metro-all.css">
+    <link rel="stylesheet" href="/static/style.css">
+    <script src="/static/js/vue.js"></script>
+    <script src="/static/js/axios.min.js"></script>
+    <script src="/static/js/timeago.js"></script>
+    <script src="/static/js/jquery.js"></script>
+    <script src="/static/js/metro.js"></script>
+  </head>
+
+  <body>
+    <div id="app">
+      <div class="container pt-4">
+        <h1>Version Chooser</h1>
+        <h3>Available Versions:</h3>
+        <div class="p-4 m-3">
+          <div class="grid">
+            <div class="p-4 m-3">
+              <h4 class="mt-0">Local Versions</h4>
+              <div class="row bg-white m-4" v-for="image in availableVersions['local']">
+                <div class="cell-5">
+                  <div class="ml-3 mt-1" style="display: inline-block; vertical-align: middle">
+                    <span class="caption">
+                      <b>{{image.tag}}</b>
+                      <code :title="image.sha">{{image.sha | shortsha}}</code>
+                      <span class="badge inline bg-green fg-white" v-if="image.sha === currentVersion.sha">Current</span>
+                      <span class="badge inline bg-blue fg-white" v-if="image.sha === currentVersion.sha">Local changes</span><br>
+                      <span class="image-small">{{image.repository}}</span>
+                    </span>
+                  </div>
+                </div>
+                <div class="cell-3">
+                  <span v-bind:title="Date(image.last_modified)">Created {{image.last_modified | asTimeAgo}}</span>
+                </div>
+                <div class="cell-4" style="text-align: right;">
+                  <div>
+                    <!-- TODO implement these
+                    <span v-if="image.sha === currentVersion.sha" class="button info disabled">
+                      <span class="mif-undo m-1"></span>
+                      Discard changes
+
+                    </span>
+                    <span v-if="image.sha === currentVersion.sha" class="button primary">
+                      <span class="mif-shift m-1"></span>
+                      Upgrade
+
+                    </span>
+                    <span v-if="image.sha !== currentVersion.sha" class="button alert disabled">
+                      <span class="mif-bin m-1"></span>
+                      Delete
+
+                    </span>
+                    -->
+                    <span
+                      v-if="image.sha !== currentVersion.sha"
+                      class="button success"
+                      @click="this.Metro.infobox.open('#infobox'); setVersion(`${image.repository}:${image.tag}`)"
+                    >
+                      <span class="mif-checkmark m-1"></span>
+                      Apply
+
+                    </span>
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="grid">
+            <div class="p-4 m-3">
+              <h4 class="mt-0">Remote Versions</h4>
+              <span class="ml-4">
+                <label>Repository</label>
+                <input type="text" required="" placeholder="bluerobotics/companion-core" id="repo" @change="loadAvailableversions" v-model="selectedImage" placeholder="edit me">
+              </span>
+              <div class="row bg-white m-4" v-for="image in availableVersions['remote']">
+                <div class="cell-5">
+                  <div class="ml-3 mt-1" style="display: inline-block; vertical-align: middle">
+                    <span class="caption">
+                      <b>{{image.tag}}</b>
+                      <code :title="image.sha">{{image.sha | shortsha}}</code>
+                    </span>
+                  </div>
+                </div>
+                <div class="cell-3">
+                  <span v-bind:title="Date(image.date)">Last updated {{image.last_modified | asTimeAgo}}</span>
+                </div>
+                <div class="cell-4" style="text-align: right;">
+                  <div>
+                    <span
+                    class="button primary"
+                    @click="this.Metro.infobox.open('#infobox'); pullVersion(`${image.repository}:${image.tag}`)"
+                    v-if="!imageIsAvailableLocally(image.sha)"
+                    >
+                      <span class="mif-download m-1"></span>
+                      Pull
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div id="infobox" class="info-box" data-role="infobox" data-width="700p">
+        <span class="button square closer"></span>
+        <div class="info-box-content">
+          <h3>Applying...</h3>
+          <p class="docker-pull-output">{{this.pullOutput}}</p>
+        </div>
+      </div>
+    </div>
+  </body>
+
+  <script>
+    /*global Metro axios, Vue, timeago*/
+    new Vue({
+      el: '#app',
+      data: function () {
+        return {
+          pullOutput: '',
+          availableVersions: {},
+          currentVersion: '',
+          waiting: false,
+          selectedImage: 'bluerobotics/companion-core',
+          Metro: null,
+        }
+      },
+      mounted () {
+        Metro.init()
+        this.Metro = Metro
+        this.loadCurrentVersion()
+        setInterval(this.checkIfBackendIsOnline, 1000)
+      },
+      methods: {
+        checkIfBackendIsOnline () {
+          axios({
+            method: 'get',
+            url: '/v1.0/version/current',
+            timeout: 500
+          })
+            .then(() => {
+              if (this.waiting) {
+                // Allow 3 seconds so the user can read the "complete" message
+                // reload(true) forces the browser to fetch the page again
+                setTimeout(() => {window.location.reload(true)} , 3000)
+              }
+            })
+            .catch((error) => {
+              console.log(error)
+              this.waiting = true
+              // show infobox while we wait for backend to come back online
+              Metro.infobox.open('#infobox')
+            })
+        },
+        loadAvailableversions () {
+          // TODO: validate repository, treat error fetching
+          axios.get('/v1.0/version/available/' + this.selectedImage).then(response => {
+            this.availableVersions = response.data
+          }).catch(() => { this.availableVersions = {} })
+        },
+        loadCurrentVersion () {
+          return axios.get('/v1.0/version/current/').then(response => {
+            const image = response.data
+            this.currentVersion = image
+            let fullname = `${image.repository}:${image.tag}`
+            this.selectedImage = fullname.split(':')[0]
+            this.loadAvailableversions()
+          })
+        },
+        pullVersion (fullname) {
+          // This streams the output of docker pull
+          console.log(fullname)
+          const [repository, tag] = fullname.split(':')
+          console.log(repository)
+          console.log(tag)
+          const layerStatus = {}
+          const layers = []
+          const layerProgress = {}
+          let overallStatus = ''
+
+          axios({
+            url: '/v1.0/version/pull',
+            method: 'POST',
+            data: {
+              repository: repository,
+              tag: tag,
+            },
+            onDownloadProgress: progressEvent => {
+            // dataChunk contains the data that have been obtained so far (the whole data so far)..
+            // The data is sent with two newlines after each message, so we split there
+            // Due to the trailing /n/n, we need the index "last -2"
+            // The received data is descbribed at
+            // https://docker-py.readthedocs.io/en/stable/api.html#docker.api.image.ImageApiMixin.pull
+              const dataChunk = progressEvent.currentTarget.response
+              const dataList = dataChunk.split('\n\n')
+
+              let data = JSON.parse(dataList[dataList.length - 2])
+              if ('id' in data) {
+                const id = data['id']
+                if (!layers.includes(id)) {
+                  layers.push(id)
+                }
+                if ('progress' in data) {
+                  layerProgress[id] = data['progress']
+                }
+                if ('status' in data) {
+                  layerStatus[id] = data['status']
+                }
+              } else {
+                overallStatus = data['status']
+              }
+              this.pullOutput = ''
+              for (let image of layers) {
+                this.pullOutput = this.pullOutput + `[${image}] ${layerStatus[image]}  ${layerProgress[image] || ''}\n`
+              }
+              this.pullOutput = this.pullOutput + `${overallStatus}\n`
+            }
+          })
+
+        },
+        setVersion (fullname) {
+          const [repository, tag] = fullname.split(':')
+          axios({
+            method: 'post',
+            url: '/v1.0/version/current',
+            data: {
+              repository: repository,
+              tag: tag,
+            }
+          })
+        },
+        imageIsAvailableLocally (sha) {
+          if (!('local' in this.availableVersions)) {
+            return false
+          }
+          return this.availableVersions['local'].some((image) => image.sha === sha)
+        }
+
+      },
+      filters: {
+        asTimeAgo: function (value) {
+          return timeago().format(new Date(Date.parse(value)), 'twitter')
+        },
+        shortsha: function (value) {
+          return value.replace('sha256:','').substring(0, 8)
+        }
+      }
+    })
+  </script>
+</html>

--- a/core/services/versionchooser/static/style.css
+++ b/core/services/versionchooser/static/style.css
@@ -1,0 +1,23 @@
+body {
+  background-color: #ECF0F5;
+}
+
+.panel .panel-title .btn-custom {
+  width: auto;
+}
+
+.disabled {
+  cursor:not-allowed;
+}
+
+#repo {
+  width: 50%;
+}
+
+.docker-pull-output {
+  white-space: pre; font-family:monospace;
+}
+
+.image-small {
+  font-size: 70%;
+}

--- a/core/services/versionchooser/test_versionchooser.py
+++ b/core/services/versionchooser/test_versionchooser.py
@@ -1,0 +1,209 @@
+import json
+from unittest import mock
+from unittest.mock import AsyncMock
+
+import pytest
+from utils.chooser import VersionChooser
+
+# All test coroutines will be treated as marked.
+pytestmark = pytest.mark.asyncio
+
+SAMPLE_JSON = """{
+    "core": {
+        "tag": "master",
+        "image": "bluerobotics/companion-core",
+        "enabled": true,
+        "webui": false,
+        "network": "host",
+        "binds": {
+            "/dev/": {
+                "bind": "/dev/",
+                "mode": "rw"
+            },
+            "/var/run/wpa_supplicant/wlan0": {
+                "bind": "/var/run/wpa_supplicant/wlan0",
+                "mode": "rw"
+            },
+            "/tmp/wpa_playground": {
+                "bind": "/tmp/wpa_playground",
+                "mode": "rw"
+            }
+        },
+        "privileged": true
+    }
+}"""
+
+SAMPLE_IMAGE = json.loads(
+    """{
+   "attrs":{
+      "date":"2021-04-09T17:51:18.065721638Z"
+   },
+   "id":"856fdf5e66c9b3697c25015556e7895c9066febb1a8ac8657a4eb41f2fc95a57"
+}"""
+)
+
+
+@pytest.mark.asyncio
+async def test_get_version() -> None:
+    """Tests if VersionChooser.get_version is reading SAMPLE_JSON properly
+
+    Interacts with:
+        - docker client (get images)
+        - Settigns file
+    """
+    client_mock = mock.MagicMock()
+    chooser = VersionChooser(client_mock)
+
+    attrs = {
+        "images.get.return_value.id": "856fdf5e66c9b3697c25015556e7895c9066febb1a8ac8657a4eb41f2fc95a57",
+        "images.get.return_value.attrs.__getitem__.return_value": {"date": "2021-04-09T17:51:18.065721638Z"},
+    }
+    client_mock.configure_mock(**attrs)
+
+    # Mock so it doesn't try to read a real file from the filesystem
+    with mock.patch("builtins.open", mock.mock_open(read_data=SAMPLE_JSON)):
+
+        response = chooser.get_version()
+        result = json.loads(response.text)
+        assert result["repository"] == "bluerobotics/companion-core"
+        assert result["tag"] == "master"
+        assert len(client_mock.mock_calls) > 0
+
+
+version = {"tag": "master", "image": "bluerobotics/companion-core", "pull": False}
+
+EXPECTED_SET_VERSION_WRITE_CALL = """{  "core": {
+    "tag": "master",
+    "image": "bluerobotics/companion-core",
+    "enabled": true,
+  '
+            '  "webui": false,
+    "network": "host",
+    "binds": {
+      "/dev/": {
+        "bind": "/dev/",
+  '
+            '      "mode": "rw"
+      },
+      "/var/run/wpa_supplicant/wlan0": {
+        "bind": "/var/run/wpa_sup'
+            'plicant/wlan0",
+        "mode": "rw"
+      },
+      "/tmp/wpa_playground": {
+        "bind": "/tmp/wp'
+            'a_playground",
+        "mode": "rw"
+      }
+    },
+    "privileged": true
+  }
+}"""
+
+
+@pytest.mark.asyncio
+@mock.patch("aiohttp.web.StreamResponse.write", new_callable=AsyncMock)
+async def test_set_version(write_mock: AsyncMock) -> None:
+    client = mock.MagicMock()
+    chooser = VersionChooser(client)
+    with mock.patch("builtins.open", mock.mock_open(read_data=SAMPLE_JSON)):
+
+        result = await chooser.set_version("bluerobotics/companion-core", "master")
+        assert await write_mock.called_once_with(EXPECTED_SET_VERSION_WRITE_CALL)
+        assert result.status == 200
+
+
+@pytest.mark.asyncio
+@mock.patch("json.load", return_value={})
+async def test_set_version_invalid_settings(json_mock: mock.MagicMock) -> None:
+    client = mock.MagicMock()
+    chooser = VersionChooser(client)
+    with mock.patch("builtins.open", mock.mock_open(read_data="{}")):
+        request_mock = AsyncMock()
+        request_mock.json = AsyncMock(return_value=version)
+        result = await chooser.set_version("bluerobotics/companion-core", "master")
+        assert result.status == 500
+        assert len(json_mock.mock_calls) > 0
+
+
+image_list = [
+    mock.MagicMock(
+        attrs={"Created": "2021-04-09T17:51:18.065721638Z", "Architecture": "amd64"},
+        id="856fdf5e66c9b3697c25015556e7895c9066febb1a8ac8657a4eb41f2fc95a57",
+        tags=["companion-core:test1"],
+    ),
+    mock.MagicMock(
+        attrs={"Created": "2021-04-09T17:51:18.065721638Z", "Architecture": "amd64"},
+        id="856fdf5e66c9b36remoteID856fdf5e66c9b36",
+        tags=["companion-core:test2"],
+    ),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.filterwarnings("ignore: Error status")  # Suppress warning of dockerhub being unavailable
+@mock.patch("aiohttp.client.ClientSession.get")
+async def test_get_available_versions_dockerhub_unavailable(
+    get_mock: mock.MagicMock,
+) -> None:
+    get_mock.configure_mock(status=500)
+    client_mock = mock.MagicMock()
+    attrs = {"images.list.return_value": image_list}
+    client_mock.configure_mock(**attrs)
+    chooser = VersionChooser(client_mock)
+    result = await chooser.get_available_versions("bluerobotics/companion-core")
+    data = json.loads(result.text)
+    assert "local" in data
+    assert "remote" in data
+    assert data["local"][0]["tag"] == "test1"
+    assert data["local"][1]["tag"] == "test2"
+    assert len(client_mock.mock_calls) > 0
+
+
+@pytest.mark.asyncio
+async def test_get_available_versions() -> None:
+    client_mock = mock.MagicMock()
+    attrs = {"images.list.return_value": image_list}
+    client_mock.configure_mock(**attrs)
+
+    chooser = VersionChooser(client_mock)
+    result = await chooser.get_available_versions("bluerobotics/companion-core")
+    data = json.loads(result.text)
+    assert "local" in data
+    assert "remote" in data
+    assert data["local"][0]["tag"] == "test1"
+    assert data["local"][1]["tag"] == "test2"
+    assert len(client_mock.mock_calls) > 0
+
+
+@pytest.mark.asyncio
+async def test_get_version_invalid_file() -> None:
+    client = mock.MagicMock()
+    with mock.patch("builtins.open", mock.mock_open(read_data="{}")):
+        chooser = VersionChooser(client)
+        response = chooser.get_version()
+        assert response.status == 500
+
+
+@pytest.mark.asyncio
+@mock.patch("json.load")
+async def test_get_version_json_exception(json_mock: mock.MagicMock) -> None:
+    client = mock.MagicMock()
+    json_mock.side_effect = Exception()
+    with mock.patch("builtins.open", mock.mock_open(read_data="")):
+        chooser = VersionChooser(client)
+        response = chooser.get_version()
+        assert response.status == 500
+        assert len(json_mock.mock_calls) > 0
+
+
+@pytest.mark.asyncio
+@mock.patch("json.load")
+async def test_set_version_json_exception(json_mock: mock.MagicMock) -> None:
+    client = mock.MagicMock()
+    json_mock.side_effect = Exception()
+    chooser = VersionChooser(client)
+    with mock.patch("builtins.open", mock.mock_open(read_data="{}")):
+        result = await chooser.set_version("bluerobotics/companion-core", "master")
+        assert result.status == 500
+        assert len(json_mock.mock_calls) > 0

--- a/core/services/versionchooser/utils/chooser.py
+++ b/core/services/versionchooser/utils/chooser.py
@@ -1,0 +1,164 @@
+import json
+import logging
+import pathlib
+from dataclasses import asdict
+from typing import Dict, List
+
+import appdirs
+import docker
+from aiohttp import web
+from utils.dockerhub import TagFetcher
+
+DOCKER_CONFIG_PATH = pathlib.Path(appdirs.user_config_dir("bootstrap"), "startup.json")
+
+current_folder = pathlib.Path(__file__).parent.parent.absolute()
+# Folder for static files (mostly css/js)
+STATIC_FOLDER = pathlib.Path.joinpath(current_folder, "static")
+
+logging.basicConfig(level=logging.INFO)
+
+
+class VersionChooser:
+    def __init__(self, client: docker.DockerClient):
+        self.client = client
+
+    @staticmethod
+    def index() -> web.FileResponse:
+        """Serve index.html"""
+        return web.FileResponse(str(STATIC_FOLDER) + "/index.html", headers={"cache-control": "no-cache"})
+
+    def get_version(self) -> web.Response:
+        """Fetches current version from config file
+
+        Returns:
+            web.Response: json with image name, tag, last modification date,
+            sha and architecture of the image
+        """
+        with open(DOCKER_CONFIG_PATH) as startup_file:
+            try:
+                core = json.load(startup_file)["core"]
+                tag = core["tag"]
+                image_name = core["image"]
+                full_name = f"{image_name}:{tag}"
+                image = self.client.images.get(full_name)
+                output = {
+                    "repository": image_name,
+                    "tag": tag,
+                    "last_modified": image.attrs["Created"],
+                    "sha": image.id,
+                    "architecture": image.attrs["Architecture"],
+                }
+                return web.json_response(output)
+            except KeyError as error:
+                return web.Response(status=500, text=f"Invalid version file: {error}")
+            except Exception as error:
+                return web.Response(status=500, text=f"Error: {type(error)}: {error}")
+
+    @staticmethod
+    def is_valid_version(_repository: str, _tag: str) -> bool:
+        # TODO implement basic validation
+        return True
+
+    async def pull_version(self, request: web.Request, repository: str, tag: str) -> web.StreamResponse:
+        """Applies a new version.
+
+        Pulls the image from dockerhub, streaming the output as a StreamResponse
+
+        Args:
+            request (web.Request): http request from aiohttp
+            repository (str): name of the image, such as bluerobotics/companion-core
+            tag (str): image tag
+
+        Returns:
+            web.StreamResponse: Streams the 'docker pull' output
+        """
+        response = web.StreamResponse()
+        response.headers["Content-Type"] = "application/x-www-form-urlencoded"
+        # This step actually starts the chunked response
+        await response.prepare(request)
+
+        low_level_api = docker.APIClient(base_url="unix://var/run/docker.sock")
+        # Stream every line of the output back to the client
+        for line in low_level_api.pull(f"{repository}:{tag}", stream=True, decode=True):
+            await response.write(f"{line}\n\n".replace("'", '"').encode("utf-8"))
+        await response.write_eof()
+        return response
+
+    async def set_version(self, image: str, tag: str) -> web.StreamResponse:
+        """Sets the current version.
+
+        Sets the version in startup.json()
+
+        Args:
+            image (str): the repository of the image
+            tag (str): the desired tag
+
+        Returns:
+            web.Response:
+                200 - OK
+                400 - Invalid image/tag
+                500 - Invalid settings file/Other internal error
+        """
+        if not self.is_valid_version(image, tag):
+            return web.Response(status=400, text="Invalid version")
+
+        with open(DOCKER_CONFIG_PATH, "r+") as startup_file:
+            try:
+                data = json.load(startup_file)
+                data["core"]["image"] = image
+                data["core"]["tag"] = tag
+
+                # overwrite file contents
+                startup_file.seek(0)
+                startup_file.write(json.dumps(data, indent=2))
+                startup_file.truncate()
+
+                logging.info("Starting bootstrap...")
+                bootstrap = self.client.containers.get("companion-bootstrap")
+                bootstrap.start()
+
+                logging.info("Stopping core...")
+                core = self.client.containers.get("companion-core")
+                core.kill()
+                return web.Response(status=200, text=f"Changed to version {image}:{tag}, restarting...")
+
+            except KeyError:
+                return web.Response(status=500, text="Invalid version file")
+
+            except Exception as error:
+                logging.critical("Error: %s: %s", type(error), error)
+                return web.Response(status=500, text=f"Error: {type(error)}: {error}")
+
+    async def get_available_versions(self, repository: str) -> web.Response:
+        """Returns versions available locally and in the remote
+
+        Args:
+            repository (str): repository name (such as bluerobotics/companion-core)
+            tag (str): tag (such as "master" or "latest")
+
+        Returns:
+            web.Response: json described in the openapi file
+        """
+        output: Dict[str, List[Dict[str, str]]] = {"local": [], "remote": []}
+        for image in self.client.images.list():
+            if not any("companion-core" in tag for tag in image.tags):
+                continue
+            for image_tag in image.tags:
+                image_repository, tag = image_tag.split(":")
+                output["local"].append(
+                    {
+                        "repository": image_repository,
+                        "tag": tag,
+                        "last_modified": image.attrs["Created"],
+                        "sha": image.id,
+                        "architecture": image.attrs["Architecture"],
+                    }
+                )
+        try:
+            online_tags = await TagFetcher().fetch_remote_tags(repository)
+        except Exception as error:
+            logging.critical("error fetching online tags: %s", error)
+            online_tags = []
+        output["remote"].extend([asdict(tag) for tag in online_tags])
+
+        return web.json_response(output)

--- a/core/services/versionchooser/utils/dockerhub.py
+++ b/core/services/versionchooser/utils/dockerhub.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""
+Responsible for interacting with dockerhub
+adapted from https://github.com/al4/docker-registry-list
+"""
+
+import platform
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+from warnings import warn
+
+import aiohttp
+
+
+def get_current_arch() -> str:
+    """Maps paltform.machine() outputs to docker architectures"""
+    arch_map = {"x86_64": "amd64", "aarch64": "arm64", "armv7l": "arm32"}  # TODO: differentiate arm64v8/ arm32v7
+    machine = platform.machine()
+    arch = arch_map.get(machine, None)
+    if not arch:
+        raise Exception(f"Unknown architecture! {machine}")
+    return arch
+
+
+@dataclass
+class TagMetadata:
+    """Class for keeping track of an item in inventory."""
+
+    repository: str
+    image: str
+    tag: str
+    last_modified: str
+    sha: Optional[str]
+    digest: str
+
+
+class TagFetcher:
+    """Fetches remote tags for a given image"""
+
+    index_url: str = "https://index.docker.io"
+    docker_url: str = "https://hub.docker.com/"
+
+    @staticmethod
+    async def _get_token(auth_url: str, image_name: str) -> str:
+        """[summary]
+        Gets a token for dockerhub.com
+        Args:
+            auth_url: authentication url, default to https://auth.docker.io
+            image_name: image name, for example "bluerobotics/core"
+
+        Raises:
+            Exception: Raised if unable to get the token
+
+        Returns:
+            The token
+        """
+        payload = {
+            "service": "registry.docker.io",
+            "scope": f"repository:{image_name}:pull",
+        }
+
+        async with aiohttp.ClientSession() as session:
+            async with session.get(auth_url + "/token", params=payload) as resp:
+                if resp.status != 200:
+                    warn(f"Error status {resp.status}")
+                    raise Exception("Could not get auth token")
+                return str((await resp.json())["token"])
+
+    async def fetch_sha(self, metadata: TagMetadata) -> str:
+        """Fetches the digest sha from a tag"""
+        header = {
+            "Authorization": f"Bearer {self.last_token}",
+            "Accept": "application/vnd.docker.distribution.manifest.v2+json",
+        }
+        tag = metadata.tag
+
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                f"{self.index_url}/v2/{metadata.repository}/manifests/{tag}", headers=header
+            ) as resp:
+                if resp.status != 200:
+                    warn(f"Error status {resp.status}")
+                    raise Exception("Failed getting sha from DockerHub!")
+                data = await resp.json()
+                return str(data["config"]["digest"])
+
+    async def fetch_remote_tags(self, repository: str) -> List[Dict[str, str]]:
+        """Fetches the tags available for an image in DockerHub"""
+        print("fetching", repository)
+
+        self.last_token = await self._get_token(auth_url="https://auth.docker.io", image_name=repository)
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                f"{self.docker_url}/v2/repositories/{repository}/tags/?page_size=25&page=1&ordering=last_updated"
+            ) as resp:
+                if resp.status != 200:
+                    warn(f"Error status {resp.status}")
+                    raise Exception("Failed getting tags from DockerHub!")
+                data = await resp.json()
+                tags = data["results"]
+
+                my_architecture = get_current_arch()
+                valid_images = []
+                for tag in tags:
+                    for image in tag["images"]:
+                        if image["architecture"] == my_architecture:
+                            tag = TagMetadata(
+                                repository=repository,
+                                image=repository.split("/")[-1],
+                                tag=tag["name"],
+                                last_modified=image["last_pushed"],
+                                sha=None,
+                                digest=image["digest"],
+                            )
+                            tag.sha = await self.fetch_sha(tag)
+
+                            valid_images.append(tag)
+                return valid_images

--- a/core/start-companion-core
+++ b/core/start-companion-core
@@ -10,6 +10,7 @@ SERVICES=(
     'helper',"$SERVICES_PATH/helper/main.py"
     'video',"mavlink-camera-manager --default-settings BlueROVUDP --verbose"
     'linux2rest',"linux2rest"
+    'versionchooser',"$SERVICES_PATH/versionchooser/main.py"
 )
 
 tmux start-server


### PR DESCRIPTION
This PR adds a Version Chooser service.

It lists all available Companion images, online and locally.
Pulls new images from dockerhub if necessary.
Updates `startup.json` to use another available image.
KIlls companion-core.

After companion-core dies. Bootstrap takes over and attempts to launch it from the edited startup.json. If the launch fails, it reverts to a default startup.json (contained in bootstrap itself).

Convenience startup.json:
```

{
    "core": {
        "tag": "versionchooser",
        "image": "williangalvani/companion-core",
        "enabled": true,
        "webui": false,
        "network": "host",
        "binds": {
            "/dev/": {
                "bind": "/dev/",
                "mode": "rw"
            },
            "/var/run/wpa_supplicant/wlan0": {
                "bind": "/var/run/wpa_supplicant/wlan0",
                "mode": "rw"
            },
            "/tmp/wpa_playground": {
                "bind": "/tmp/wpa_playground",
                "mode": "rw"
            },
            "/var/run/docker.sock": {
                "bind": "/var/run/docker.sock",
                "mode": "rw"
            }
        },
        "privileged": true
    }
}




```