### PR TITLE
install: Break installation method in bcm27 and bcm28 scripts

### DIFF
--- a/install/boards/bcm_27xx.sh
+++ b/install/boards/bcm_27xx.sh
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
 
-# Running in a BCM27/28, do necessary (Raspberry)
-echo "Configuring BCM27/28 board.."
+echo "Configuring BCM27XX board (Raspberry Pi 4).."
 
 # Remove any configuration related to i2c and spi/spi1 and do the necessary changes for navigator
 echo "- Enable I2C, SPI and UART."
-for STRING in "dtparam=i2c_arm=" "dtparam=spi=" "dtoverlay=spi1" "dtoverlay=uart1"; do
+for STRING in "dtparam=i2c_arm=" "dtparam=spi=" "dtoverlay=spi1" "dtoverlay=i2c4" "dtoverlay=uart1"; do
     sudo sed -i "/$STRING/d" /boot/config.txt
 done
-for STRING in "dtparam=i2c_arm=on" "dtparam=spi=on" "dtoverlay=spi1-3cs" "dtoverlay=uart1"; do
+for STRING in "dtparam=i2c_arm=on" "dtparam=spi=on" "dtoverlay=spi1-3cs" "dtoverlay=i2c4,pins_6_7" "dtoverlay=uart1"; do
     echo "$STRING" | sudo tee -a /boot/config.txt
 done
 
@@ -22,7 +21,7 @@ fi
 
 echo "- Set up kernel modules."
 # Remove any configuration or commented part related to the i2c drive
-for STRING in "bcm2835-v4l2" "i2c-bcm2708" "i2c-dev"; do
+for STRING in "bcm2835-v4l2" "i2c-bcm2835" "i2c-dev"; do
     sudo sed -i "/$STRING/d" "$MODULES_FILE"
     echo "$STRING" | sudo tee -a "$MODULES_FILE"
 done

--- a/install/boards/bcm_28xx.sh
+++ b/install/boards/bcm_28xx.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+echo "Configuring BCM28XX board (Raspberry Pi zero, 1, 2, 3).."
+
+# Remove any configuration related to i2c and spi/spi1 and do the necessary changes for navigator
+echo "- Enable I2C, SPI and UART."
+for STRING in "dtparam=i2c_arm=" "dtparam=spi=" "dtoverlay=spi1" "dtoverlay=uart1"; do
+    sudo sed -i "/$STRING/d" /boot/config.txt
+done
+for STRING in "dtparam=i2c_arm=on" "dtparam=spi=on" "dtoverlay=spi1-3cs" "dtoverlay=uart1"; do
+    echo "$STRING" | sudo tee -a /boot/config.txt
+done
+
+# Check for valid modules file to load kernel modules
+if [ -f "/etc/modules" ]; then
+    MODULES_FILE="/etc/modules"
+else
+    MODULES_FILE="/etc/modules-load.d/companion.conf"
+    touch "$MODULES_FILE" || true # Create if it does not exist
+fi
+
+echo "- Set up kernel modules."
+# Remove any configuration or commented part related to the i2c drive
+for STRING in "bcm2835-v4l2" "i2c-bcm2835" "i2c-dev"; do
+    sudo sed -i "/$STRING/d" "$MODULES_FILE"
+    echo "$STRING" | sudo tee -a "$MODULES_FILE"
+done
+
+# Remove any console serial configuration
+echo "- Configure serial."
+sudo sed -e 's/console=serial[0-9],[0-9]*\ //' -i /boot/cmdline.txt

--- a/install/boards/configure_board.sh
+++ b/install/boards/configure_board.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# Detect and configure hardware for each supported plataform
+
+VERSION="${VERSION:-master}"
+REMOTE="${REMOTE:-https://raw.githubusercontent.com/bluerobotics/companion-docker}"
+REMOTE="$REMOTE/$VERSION"
+CONFIGURE_BOARD_PATH="$REMOTE/install/boards"
+
+function board_not_detected {
+    echo "Hardware not identified in $1, please repport back the following line:"
+    echo "---"
+    echo "$(echo $2 | gzip | base64 -w0)" # Decode with `echo $CONTENT | base64 -d | gunzip`
+    echo "---"
+}
+
+# device-tree/model is not standard but is the only way to detect raspberry pi hardware reliable
+#  From Raspberry Pi official website about Raspberry Pi 4 cpuinfo:
+#  Why does cpuinfo report I have a BCM2835?
+#     The upstream Linux kernel developers had decided that all models of Raspberry Pi return bcm2835 as the SoC name.
+#     Unfortunately it means that cat /proc/cpuinfo is inaccurate for the Raspberry Pi 2, Raspberry Pi 3 and Raspberry Pi 4,
+#     which use the bcm2836/bcm2837, bcm2837 and bcm2711 respectively.
+#     You can use cat /proc/device-tree/model to get an accurate description of the SoC on your Raspberry Pi model.
+if [ -f "/proc/device-tree/model" ]; then
+    CPU_MODEL=$(tr -d '\0' < /proc/device-tree/model)
+    if [[ $CPU_MODEL =~ Raspberry\ Pi\ [0-3] ]]; then
+        curl -fsSL $CONFIGURE_BOARD_PATH/bcm_28xx.sh | bash
+    elif [[ $CPU_MODEL =~ Raspberry\ Pi\ [4] ]];then
+        curl -fsSL $CONFIGURE_BOARD_PATH/bcm_27xx.sh | bash
+    else
+        board_not_detected "/proc/device-tree/model" "$CPU_MODEL"
+    fi
+
+# If the previous file does not exist, we are going to try the old method and do our best
+elif [ -f "/proc/cpuinfo" ]; then
+    CPU_INFO="$(cat /proc/cpuinfo)"
+    if [[ $CPU_INFO =~ BCM27[0-9]{2} ]]; then
+        curl -fsSL $CONFIGURE_BOARD_PATH/bcm_27xx.sh | bash
+    elif [[ $CPU_INFO =~ BCM28[0-9]{2} ]]; then
+        curl -fsSL $CONFIGURE_BOARD_PATH/bcm_28xx.sh | bash
+    else
+        board_not_detected "/proc/cpuinfo" "$CPU_INFO"
+    fi
+
+else
+    echo "Impossible to detect hardware, aborting."
+    exit -1
+fi

--- a/install/install.sh
+++ b/install/install.sh
@@ -18,10 +18,8 @@ set -e
 [[ $EUID != 0 ]] && echo "Script must run as root."  && exit 1
 
 # Detect CPU and do necessary hardware configuration for each supported hardware
-CPU_INFO="$(cat /proc/cpuinfo)"
-echo $CPU_INFO | grep -Eq "BCM(27|28)" && (
-    curl -fsSL $REMOTE/install/boards/bcm_28_27.sh | bash
-)
+echo "Starting hardware configuration."
+curl -fsSL $REMOTE/install/boards/configure_board.sh | bash
 
 echo "Checking for blocked wifi and bluetooth."
 rfkill unblock all


### PR DESCRIPTION
How to test:
```sh
export VERSION="break_install";export REMOTE="https://raw.githubusercontent.com/patrickelectric/companion-docker";
curl -fsSL $REMOTE/$VERSION/install/boards/configure_board.sh | bash
```
Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>