### PR TITLE
Bootstrap: handle invalid image names

### DIFF
--- a/bootstrap/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap/bootstrap.py
@@ -145,14 +145,20 @@ class Bootstrapper:
             warn(f"Error trying to pull an update image: {error}")
 
         print("Starting core")
-        self.client.containers.run(
-            f"{image}:{core_version}",
-            name=Bootstrapper.CORE_CONTAINER_NAME,
-            volumes=binds,
-            privileged=privileged,
-            network=network,
-            detach=True,
-        )
+        try:
+            self.client.containers.run(
+                f"{image}:{core_version}",
+                name=Bootstrapper.CORE_CONTAINER_NAME,
+                volumes=binds,
+                privileged=privileged,
+                network=network,
+                detach=True,
+            )
+        except docker.errors.APIError as error:
+            warn(f"Error trying to start image: {error}, reverting to default...")
+            self.overwrite_config_file_with_defaults()
+            return False
+
         print("Core started")
         return True
 

--- a/bootstrap/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap/bootstrap.py
@@ -28,6 +28,13 @@ class Bootstrapper:
     @staticmethod
     def overwrite_config_file_with_defaults() -> None:
         """Overwrites the config file with the default configuration"""
+        try:
+            shutil.copy(
+                Bootstrapper.DOCKER_CONFIG_FILE_PATH, Bootstrapper.DOCKER_CONFIG_FILE_PATH.with_suffix(".json.bak")
+            )
+        except FileNotFoundError:
+            # we don't mind if the file is already there
+            pass
         shutil.copy(Bootstrapper.DEFAULT_FILE_PATH, Bootstrapper.DOCKER_CONFIG_FILE_PATH)
 
     @staticmethod


### PR DESCRIPTION
Fix #69 

to test, change the image name in startup.json and then run:

```
docker run \                                                                                             
    -it \
    --rm  \
    --name companion_bootstrap \
    -v $HOME/.config/companion:/root/.config/companion \
    -v /var/run/docker.sock:/var/run/docker.sock \
    -e COMPANION_CONFIG_PATH=$HOME/.config/companion \
    williangalvani/bootstrap:missingimage
```