### PR TITLE
ardupilot_manager: Detector: use IntEnum instead of Enum

### DIFF
--- a/core/services/ardupilot_manager/flight_controller_detector/Detector.py
+++ b/core/services/ardupilot_manager/flight_controller_detector/Detector.py
@@ -1,11 +1,11 @@
 import os
-from enum import Enum
+from enum import IntEnum
 from typing import List, Tuple
 
 from smbus2 import SMBus
 
 
-class FlightControllerType(Enum):
+class FlightControllerType(IntEnum):
     Serial = 1
     Navigator = 2
 


### PR DESCRIPTION
Fixes a new mypy issue caused by the comparison of objects which do not implement the "less than" operator:

`
core/services/ardupilot_manager/main.py:101: error: Returning Any from function declared to return "_SupportsLessThan"
Found 1 error in 1 file (checked 1 source file)
`