### PR TITLE
Upload code coverage as artifacts

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -30,3 +30,8 @@ jobs:
       name: Run tests
       run: |
         ./.hooks/pre-push
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: coverage
+        path: htmlcov

--- a/.hooks/pre-push
+++ b/.hooks/pre-push
@@ -18,6 +18,6 @@ echo "Running mypy.."
 git ls-files '*.py' | xargs --max-lines=1 mypy --ignore-missing-imports --warn-unreachable --allow-untyped-decorators --strict
 
 echo "Running pytest.."
-pytest --cov="$repository_path" --cov-config="$repository_path/.coveragerc"
+pytest --cov="$repository_path" --cov-config="$repository_path/.coveragerc" --cov-report html --cov-report term
 
 exit 0


### PR DESCRIPTION
This uploads the coverage html as an action artifact:

![image](https://user-images.githubusercontent.com/4013804/97647614-75fa7500-1a31-11eb-98be-1c82cde8626c.png)

I need it as I'm facing different results in my machine and in Github Actions.


close #76 