### PR TITLE
README: Add sudo in bash command

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -5,5 +5,5 @@ This folder contains all necessary files for configuration of the host computer 
 To use it, just run the following line in your terminal:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/bluerobotics/companion-docker/master/install/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/bluerobotics/companion-docker/master/install/install.sh | sudo bash
 ```


### PR DESCRIPTION
Usually the command will be run in a normal user as "pi", so sudo is necessary to have permission.