### PR TITLE
install: Add note to run command as root user

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -2,7 +2,7 @@
 
 This folder contains all necessary files for configuration of the host computer and installation of companion-docker.
 
-To use it, just run the following line in your terminal:
+To use it, just run the following line in your terminal **as root**:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/bluerobotics/companion-docker/master/install/install.sh | bash


### PR DESCRIPTION
We can't set the call to be sudo bash, since docker will be unable to access tty output

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>