### PR TITLE
install: udev: Change autopilot manufacturer to match any PX4 prefix

### DIFF
--- a/install/udev/100.autopilot.rules
+++ b/install/udev/100.autopilot.rules
@@ -1,2 +1,2 @@
-SUBSYSTEM=="tty", ATTRS{manufacturer}=="3D Robotics", ATTRS{product}=="PX4 FMU v2.x", SYMLINK+="autopilot"
+SUBSYSTEM=="tty", ATTRS{manufacturer}=="3D Robotics", ATTRS{product}=="PX4*", SYMLINK+="autopilot"
 SUBSYSTEM=="tty", ATTRS{manufacturer}=="ArduPilot", SYMLINK+="autopilot"


### PR DESCRIPTION
This will capture any PX4 device, that is a flight controller unit.
It also fixes any problem related to 'PX4 FMU' (controller software)
and 'PX4 BL FMU' (bootloader).

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>