### PR TITLE
install/README: update install instructions to prevent user mistake

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -2,8 +2,8 @@
 
 This folder contains all necessary files for configuration of the host computer and installation of companion-docker.
 
-To use it, just run the following line in your terminal **as root**:
+To use it, just run the installation script in your terminal **as root**, like so:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/bluerobotics/companion-docker/master/install/install.sh | bash
+sudo su -c 'curl -fsSL https://raw.githubusercontent.com/bluerobotics/companion-docker/master/install/install.sh | bash'
 ```


### PR DESCRIPTION
It's easy to just put a `sudo` before the entire command and forget to also run bash as root.
Suggesting `sudo su` prevents people from doing that.