### PR TITLE
ArduPilotManager: turn class into Singleton

### DIFF
--- a/core/services/ardupilot_manager/ArduPilotManager.py
+++ b/core/services/ardupilot_manager/ArduPilotManager.py
@@ -13,9 +13,10 @@ from flight_controller_detector.Detector import FlightControllerType
 from mavlink_proxy.Endpoint import Endpoint
 from mavlink_proxy.Manager import Manager as MavlinkManager
 from settings import Settings
+from Singleton import Singleton
 
 
-class ArduPilotManager:
+class ArduPilotManager(metaclass=Singleton):
     def __init__(self) -> None:
         self.settings = Settings()
         self.mavlink_manager = MavlinkManager()

--- a/core/services/ardupilot_manager/Singleton.py
+++ b/core/services/ardupilot_manager/Singleton.py
@@ -1,0 +1,10 @@
+from typing import Any, Dict
+
+
+class Singleton(type):
+    _instances: Dict[Any, Any] = {}
+
+    def __call__(cls: Any, *args: Any, **kwargs: Any) -> Any:
+        if cls not in cls._instances:
+            cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
+        return cls._instances[cls]


### PR DESCRIPTION
With the current code structure, it only makes sense to have one instance of the manager running.