### PR TITLE
bootstrap: Fix bind to .config

### DIFF
--- a/bootstrap/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap/bootstrap.py
@@ -14,7 +14,7 @@ class Bootstrapper:
 
     DEFAULT_FILE_PATH = pathlib.Path("/bootstrap/startup.json.default")
     DOCKER_CONFIG_PATH = pathlib.Path("/root/.config")
-    DOCKER_CONFIG_FILE_PATH = pathlib.Path(DOCKER_CONFIG_PATH, "startup.json")
+    DOCKER_CONFIG_FILE_PATH = DOCKER_CONFIG_PATH.joinpath("bootstrap/startup.json")
     HOST_CONFIG_PATH = os.environ.get("COMPANION_CONFIG_PATH", "/tmp/companion/.config")
     CORE_CONTAINER_NAME = "companion-core"
 

--- a/bootstrap/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap/bootstrap.py
@@ -15,7 +15,7 @@ class Bootstrapper:
     DEFAULT_FILE_PATH = pathlib.Path("/bootstrap/startup.json.default")
     DOCKER_CONFIG_PATH = pathlib.Path("/root/.config/companion/")
     DOCKER_CONFIG_FILE_PATH = pathlib.Path(DOCKER_CONFIG_PATH, "startup.json")
-    HOST_CONFIG_PATH = os.environ.get("COMPANION_CONFIG_PATH", None)
+    HOST_CONFIG_PATH = os.environ.get("COMPANION_CONFIG_PATH", "/tmp/companion/.config")
     CORE_CONTAINER_NAME = "companion-core"
 
     def __init__(self, client: docker.DockerClient, low_level_api: docker.APIClient = None) -> None:

--- a/bootstrap/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap/bootstrap.py
@@ -29,6 +29,13 @@ class Bootstrapper:
     def overwrite_config_file_with_defaults() -> None:
         """Overwrites the config file with the default configuration"""
         try:
+            os.makedirs(pathlib.Path(Bootstrapper.DOCKER_CONFIG_FILE_PATH).parent, exist_ok=True)
+        except Exception as exception:
+            raise RuntimeError(
+                f"Failed to create folder for configuration file: {Bootstrapper.DOCKER_CONFIG_FILE_PATH}"
+            ) from exception
+
+        try:
             shutil.copy(
                 Bootstrapper.DOCKER_CONFIG_FILE_PATH, Bootstrapper.DOCKER_CONFIG_FILE_PATH.with_suffix(".json.bak")
             )

--- a/bootstrap/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap/bootstrap.py
@@ -13,7 +13,7 @@ import docker
 class Bootstrapper:
 
     DEFAULT_FILE_PATH = pathlib.Path("/bootstrap/startup.json.default")
-    DOCKER_CONFIG_PATH = pathlib.Path("/root/.config/companion/")
+    DOCKER_CONFIG_PATH = pathlib.Path("/root/.config")
     DOCKER_CONFIG_FILE_PATH = pathlib.Path(DOCKER_CONFIG_PATH, "startup.json")
     HOST_CONFIG_PATH = os.environ.get("COMPANION_CONFIG_PATH", "/tmp/companion/.config")
     CORE_CONTAINER_NAME = "companion-core"

--- a/install/install.sh
+++ b/install/install.sh
@@ -75,7 +75,7 @@ docker run \
     -t \
     --restart unless-stopped \
     --name companion-bootstrap \
-    -v $HOME/.config/companion:/root/.config/companion \
+    -v $HOME/.config/companion/bootstrap:/root/.config/bootstrap \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -e COMPANION_CONFIG_PATH=$HOME/.config/companion \
     $COMPANION_BOOTSTRAP


### PR DESCRIPTION
This allows us to store and load companion-core settings 