### PR TITLE
core: start-companion-core: Use BlueROV default settings for  mavlink-camera-manager

### DIFF
--- a/core/start-companion-core
+++ b/core/start-companion-core
@@ -8,7 +8,7 @@ SERVICES=(
     'wifi',"$SERVICES_PATH/wifi/main.py"
     'autopilot',"$SERVICES_PATH/ardupilot_manager/main.py"
     'helper',"$SERVICES_PATH/helper/main.py"
-    'video',"mavlink-camera-manager --verbose"
+    'video',"mavlink-camera-manager --default-settings BlueROVUDP --verbose"
 )
 
 tmux start-server

--- a/core/tools/mavlink_camera_manager/bootstrap.sh
+++ b/core/tools/mavlink_camera_manager/bootstrap.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 LOCAL_BINARY_PATH="/usr/bin/mavlink-camera-manager"
-REMOTE_BINARY_URL="https://github.com/patrickelectric/mavlink-camera-manager/releases/download/t3.0.0/mavlink-camera-manager-armv7"
+REMOTE_BINARY_URL="https://github.com/patrickelectric/mavlink-camera-manager/releases/download/t3.0.1/mavlink-camera-manager-armv7"
 
 # Download and install the camera manager under user binary folder with the correct permissions
 DEBIAN_FRONTEND=noninteractive apt --yes install wget


### PR DESCRIPTION
- It'll generate a stream per camera that provides H264 stream, each stream will be a udp://192.168.2.1:(5600 + stream_index)