### PR TITLE
core: remove i2c0 from navigator autopilot board detection

### DIFF
--- a/core/services/ardupilot_manager/flight_controller_detector/Detector.py
+++ b/core/services/ardupilot_manager/flight_controller_detector/Detector.py
@@ -29,10 +29,6 @@ class Detector:
                 String is always empty
         """
         try:
-            bus = SMBus(0)
-            EEPROM_address = 0x50
-            bus.read_byte_data(EEPROM_address, 0)
-
             bus = SMBus(1)
             ADS1115_address = 0x48
             bus.read_byte_data(ADS1115_address, 0)


### PR DESCRIPTION
i2c0 is not workable on latest raspberry pi os image, this is preventing ardusub from starting up

will have to dig around more to figure out what's wrong with i2c0 on latest raspberry pi os image (it's working fine on previous buster images)