### PR TITLE
gitingore: Add env folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.pytest_cache
 .coverage
 htmlcov/
+env/


### PR DESCRIPTION
env/ folder is traditionally used to store virtualenvs in python projects