### PR TITLE
core: ardupilot_manager: use shutil instead of os to move file

### DIFF
--- a/core/services/ardupilot_manager/ArduPilotManager.py
+++ b/core/services/ardupilot_manager/ArduPilotManager.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import stat
 import subprocess
 import time
@@ -50,9 +51,9 @@ class ArduPilotManager(metaclass=Singleton):
         if not os.path.isfile(firmware):
             temporary_file = self.firmware_download.download(Vehicle.Sub, "Navigator")
             assert temporary_file, "Failed to download navigator binary."
+            shutil.move(str(temporary_file), firmware)
             # Make the binary executable
-            os.chmod(temporary_file, stat.S_IXOTH)
-            os.rename(temporary_file, firmware)
+            os.chmod(firmware, stat.S_IXOTH)
         try:
             subprocess.check_output([firmware, "--help"])
         except Exception as error:


### PR DESCRIPTION
os fails to move files between different mounts 'invalid cross-device link'

fix #135 