### PR TITLE
Fix endpoints loading

### DIFF
--- a/core/services/ardupilot_manager/ArduPilotManager.py
+++ b/core/services/ardupilot_manager/ArduPilotManager.py
@@ -114,8 +114,7 @@ class ArduPilotManager(metaclass=Singleton):
         """Load endpoints from the configuration file to the mavlink manager."""
         if "endpoints" not in self.configuration:
             self.configuration["endpoints"] = []
-        else:
-            endpoints = self.configuration["endpoints"]
+        endpoints = self.configuration["endpoints"]
         for endpoint in endpoints:
             if not self.add_endpoint(Endpoint(**endpoint)):
                 warn(f"Could not load endpoint {endpoint}")


### PR DESCRIPTION
When there was no "endpoints" key in settings file, ```UnboundLocalError``` was raised.