### PR TITLE
core: ardupilot-manager: Make Endpoints hashable

### DIFF
--- a/core/services/ardupilot_manager/mavlink_proxy/Endpoint.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/Endpoint.py
@@ -59,6 +59,9 @@ class Endpoint:
             "argument": self.argument,
         }
 
+    def __hash__(self) -> int:
+        return hash(str(self))
+
 
 VALID_SERIAL_BAUDRATES = [
     3000000,


### PR DESCRIPTION
Will allow easier validating and duplication verification in the future.