### PR TITLE
Fix and extend endpoint types

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,17 @@ jobs:
         pip install mavproxy
         pip install pyfakefs pytest-cov pytest-timeout pylint mypy isort black
         find . -type f -name "setup.py" | xargs --max-lines=1 --replace=% python % install --user
+
+        MAVLINK_ROUTER_PATH="/tmp/mavlink-router"
+        sudo apt install autoconf g++ git libtool make pkg-config python3-future
+        mkdir ${MAVLINK_ROUTER_PATH}
+        git clone --depth 1 --branch master https://github.com/mavlink-router/mavlink-router ${MAVLINK_ROUTER_PATH}
+        cd ${MAVLINK_ROUTER_PATH}
+        git submodule update --init --recursive --quiet
+        ./autogen.sh
+        ./configure --disable-systemd CFLAGS='-g -O2' --sysconfdir=/etc --localstatedir=/var --libdir=/usr/lib64 --prefix=/usr
+        sudo make install
+        rm -rf {MAVLINK_ROUTER_PATH}
     -
       name: Run tests
       run: |

--- a/core/services/ardupilot_manager/ArduPilotManager.py
+++ b/core/services/ardupilot_manager/ArduPilotManager.py
@@ -116,8 +116,11 @@ class ArduPilotManager(metaclass=Singleton):
             self.configuration["endpoints"] = []
         endpoints = self.configuration["endpoints"]
         for endpoint in endpoints:
-            if not self.mavlink_manager.add_endpoint(Endpoint(**endpoint)):
-                warn(f"Could not load endpoint {endpoint}")
+            try:
+                if not self.mavlink_manager.add_endpoint(Endpoint(**endpoint)):
+                    raise ValueError("Cannot add endpoint.")
+            except Exception as error:
+                warn(f"Could not load endpoint {endpoint}. {error}")
 
     def _reset_endpoints(self, endpoints: List[Endpoint]) -> None:
         try:

--- a/core/services/ardupilot_manager/ArduPilotManager.py
+++ b/core/services/ardupilot_manager/ArduPilotManager.py
@@ -10,7 +10,7 @@ from warnings import warn
 from firmware_download.FirmwareDownload import FirmwareDownload, Vehicle
 from flight_controller_detector.Detector import Detector as BoardDetector
 from flight_controller_detector.Detector import FlightControllerType
-from mavlink_proxy.Endpoint import Endpoint, EndpointType
+from mavlink_proxy.Endpoint import Endpoint
 from mavlink_proxy.Manager import Manager as MavlinkManager
 from settings import Settings
 from Singleton import Singleton
@@ -142,10 +142,6 @@ class ArduPilotManager(metaclass=Singleton):
 
     def add_new_endpoints(self, new_endpoints: List[Endpoint]) -> bool:
         """Add multiple endpoints to the mavlink manager and save them on the configuration file."""
-        for endpoint in new_endpoints:
-            if endpoint.connection_type == EndpointType.File.value:
-                endpoint.place = os.path.join(self.settings.file_endpoints_path, endpoint.place)
-
         saved_endpoints = deepcopy(self.configuration["endpoints"])
         loaded_endpoints = deepcopy(self.get_endpoints())
 

--- a/core/services/ardupilot_manager/mavlink_proxy/Endpoint.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/Endpoint.py
@@ -9,7 +9,8 @@ from pydantic.dataclasses import dataclass
 class EndpointType(str, Enum):
     UDPServer = "udpin"
     UDPClient = "udpout"
-    TCP = "tcp"
+    TCPServer = "tcp"
+    TCPClient = "tcpout"
     Serial = "serial"
     File = "file"
 
@@ -25,7 +26,12 @@ class Endpoint:
     def is_mavlink_endpoint(cls: Type["Endpoint"], values: Any) -> Any:
         connection_type, place, argument = (values.get("connection_type"), values.get("place"), values.get("argument"))
 
-        if connection_type in [EndpointType.UDPServer, EndpointType.UDPClient, EndpointType.TCP]:
+        if connection_type in [
+            EndpointType.UDPServer,
+            EndpointType.UDPClient,
+            EndpointType.TCPServer,
+            EndpointType.TCPClient,
+        ]:
             if not (validators.domain(place) or validators.ipv4(place) or validators.ipv6(place)):
                 raise ValueError(f"Invalid network address: {place}")
             if not argument in range(1, 65536):

--- a/core/services/ardupilot_manager/mavlink_proxy/Endpoint.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/Endpoint.py
@@ -9,7 +9,7 @@ from pydantic.dataclasses import dataclass
 class EndpointType(str, Enum):
     UDPServer = "udpin"
     UDPClient = "udpout"
-    TCPServer = "tcp"
+    TCPServer = "tcpin"
     TCPClient = "tcpout"
     Serial = "serial"
     File = "file"

--- a/core/services/ardupilot_manager/mavlink_proxy/Endpoint.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/Endpoint.py
@@ -12,7 +12,6 @@ class EndpointType(str, Enum):
     TCPServer = "tcpin"
     TCPClient = "tcpout"
     Serial = "serial"
-    File = "file"
 
 
 @dataclass
@@ -43,13 +42,6 @@ class Endpoint:
                 raise ValueError(f"Bad serial address: {place}. Make sure to use an absolute path.")
             if not argument in VALID_SERIAL_BAUDRATES:
                 raise ValueError(f"Invalid serial baudrate: {argument}. Valid option are {VALID_SERIAL_BAUDRATES}.")
-            return values
-
-        if connection_type == EndpointType.File.value:
-            if "/" in place:
-                raise ValueError(f"Bad filename: {place}. Valid filenames do not contain '/' characters.")
-            if argument is not None:
-                raise ValueError(f"File endpoint should have no argument. Received {argument}.")
             return values
 
         raise ValueError(

--- a/core/services/ardupilot_manager/mavlink_proxy/MAVLinkRouter.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/MAVLinkRouter.py
@@ -26,11 +26,10 @@ class MAVLinkRouter(AbstractRouter):
         def convert_endpoint(endpoint: Endpoint) -> str:
             # TCP uses a special argument and only works with localhost
             if endpoint.connection_type == EndpointType.TCPServer:
-                port = str(endpoint).split(":")[2]
-                return f"-t {port}"
+                return f"--tcp-port {endpoint.argument}"
             if endpoint.connection_type == EndpointType.TCPClient:
                 return f"--tcp-endpoint {endpoint.place}:{endpoint.argument}"
-            return str(endpoint)[str(endpoint).find(":") + 1 :]
+            return f"{endpoint.place}:{endpoint.argument}"
 
         endpoints = " ".join(["--endpoint " + convert_endpoint(endpoint) for endpoint in self.endpoints()])
 

--- a/core/services/ardupilot_manager/mavlink_proxy/MAVLinkRouter.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/MAVLinkRouter.py
@@ -24,11 +24,13 @@ class MAVLinkRouter(AbstractRouter):
     def assemble_command(self, master: Endpoint) -> str:
         # Convert endpoint format to mavlink-router format
         def convert_endpoint(endpoint: Endpoint) -> str:
-            if endpoint.connection_type != EndpointType.TCP:
-                return str(endpoint)[str(endpoint).find(":") + 1 :]
             # TCP uses a special argument and only works with localhost
-            port = str(endpoint).split(":")[2]
-            return f"-t {port}"
+            if endpoint.connection_type == EndpointType.TCPServer:
+                port = str(endpoint).split(":")[2]
+                return f"-t {port}"
+            if endpoint.connection_type == EndpointType.TCPClient:
+                return f"--tcp-endpoint {endpoint.place}:{endpoint.argument}"
+            return str(endpoint)[str(endpoint).find(":") + 1 :]
 
         endpoints = " ".join(["--endpoint " + convert_endpoint(endpoint) for endpoint in self.endpoints()])
 
@@ -36,7 +38,7 @@ class MAVLinkRouter(AbstractRouter):
             EndpointType.UDPServer,
             EndpointType.UDPClient,
             EndpointType.Serial,
-            EndpointType.TCP,
+            EndpointType.TCPServer,
         ]:
             raise NotImplementedError
 

--- a/core/services/ardupilot_manager/mavlink_proxy/MAVProxy.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/MAVProxy.py
@@ -21,17 +21,22 @@ class MAVProxy(AbstractRouter):
         return None
 
     def assemble_command(self, master: Endpoint) -> str:
-        endpoints = " ".join([f"--out={str(endpoint)}" for endpoint in self.endpoints()])
+        endpoints_string = ""
+        for endpoint in self.endpoints():
+            if endpoint.connection_type != EndpointType.Serial:
+                endpoints_string += f" --out={str(endpoint)}"
+            else:
+                endpoints_string += f" --out={endpoint.place},{endpoint.argument}"
 
         master_string = str(master)
         if master.connection_type == EndpointType.Serial:
             if not master.argument:
                 master_string = f"{master.place}"
             else:
-                master_string = f"{master.place} --baudrate={master.argument}"
+                master_string = f"{master.place},{master.argument}"
 
         log = f"--state-basedir={self.logdir().resolve()}"
-        return f"{self.binary()} --master={master_string} {endpoints} {log} --non-interactive"
+        return f"{self.binary()} --master={master_string} {endpoints_string} {log} --non-interactive"
 
     @staticmethod
     def name() -> str:

--- a/core/services/ardupilot_manager/mavlink_proxy/MAVProxy.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/MAVProxy.py
@@ -48,7 +48,13 @@ class MAVProxy(AbstractRouter):
 
     @staticmethod
     def _validate_endpoint(endpoint: Endpoint) -> bool:
-        return True
+        return endpoint.connection_type in [
+            EndpointType.Serial,
+            EndpointType.UDPServer,
+            EndpointType.UDPClient,
+            EndpointType.TCPServer,
+            EndpointType.TCPClient,
+        ]
 
     @staticmethod
     def is_ok() -> bool:

--- a/core/services/ardupilot_manager/mavlink_proxy/MAVProxy.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/MAVProxy.py
@@ -21,15 +21,14 @@ class MAVProxy(AbstractRouter):
         return None
 
     def assemble_command(self, master: Endpoint) -> str:
-        endpoints = " ".join(["--out=" + endpoint.__str__() for endpoint in self.endpoints()])
+        endpoints = " ".join([f"--out={str(endpoint)}" for endpoint in self.endpoints()])
 
         master_string = str(master)
         if master.connection_type == EndpointType.Serial:
-            master_args = str(master).split(":")
-            if len(master_args) == 2:
-                master_string = f"{master_args[1]}"
+            if not master.argument:
+                master_string = f"{master.place}"
             else:
-                master_string = f"{master_args[1]} --baudrate={master_args[2]}"
+                master_string = f"{master.place} --baudrate={master.argument}"
 
         log = f"--state-basedir={self.logdir().resolve()}"
         return f"{self.binary()} --master={master_string} {endpoints} {log} --non-interactive"

--- a/core/services/ardupilot_manager/mavlink_proxy/test_all.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/test_all.py
@@ -98,5 +98,5 @@ def test_mavlink_router() -> None:
         endpoint_2,
     ], "Endpoint list does not match."
 
-    assert mavlink_router.start(Endpoint("udpout", "0.0.0.0", 14550)), "Failed to start MAVLinkRouter"
+    assert mavlink_router.start(Endpoint("udpin", "0.0.0.0", 14550)), "Failed to start MAVLinkRouter"
     assert mavlink_router.is_running(), "MAVLinkRouter is not running after start."

--- a/core/services/ardupilot_manager/mavlink_proxy/test_all.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/test_all.py
@@ -33,7 +33,6 @@ def test_endpoint_validators() -> None:
     Endpoint.is_mavlink_endpoint({"connection_type": "udpin", "place": "0.0.0.0", "argument": 14550})
     Endpoint.is_mavlink_endpoint({"connection_type": "udpout", "place": "0.0.0.0", "argument": 14550})
     Endpoint.is_mavlink_endpoint({"connection_type": "serial", "place": "/dev/autopilot", "argument": 115200})
-    Endpoint.is_mavlink_endpoint({"connection_type": "file", "place": "mavlink_dump"})
     with pytest.raises(ValueError):
         Endpoint.is_mavlink_endpoint({"connection_type": "udpin", "place": "0.0.0.0", "argument": -30})
     with pytest.raises(ValueError):
@@ -42,10 +41,6 @@ def test_endpoint_validators() -> None:
         Endpoint.is_mavlink_endpoint({"connection_type": "serial", "place": "dev/autopilot", "argument": 115200})
     with pytest.raises(ValueError):
         Endpoint.is_mavlink_endpoint({"connection_type": "serial", "place": "/dev/autopilot", "argument": 100000})
-    with pytest.raises(ValueError):
-        Endpoint.is_mavlink_endpoint({"connection_type": "file", "place": "mavlink_dump", "argument": 10})
-    with pytest.raises(ValueError):
-        Endpoint.is_mavlink_endpoint({"connection_type": "file", "place": "/path/to/file"})
     with pytest.raises(ValueError):
         Endpoint.is_mavlink_endpoint({"connection_type": "potato", "place": "path/to/file", "argument": 100})
 

--- a/core/services/ardupilot_manager/mavlink_proxy/test_all.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/test_all.py
@@ -29,6 +29,9 @@ def test_endpoint() -> None:
 
 def test_endpoint_validators() -> None:
     Endpoint.is_mavlink_endpoint({"connection_type": "tcpin", "place": "0.0.0.0", "argument": 14550})
+    Endpoint.is_mavlink_endpoint({"connection_type": "tcpout", "place": "0.0.0.0", "argument": 14550})
+    Endpoint.is_mavlink_endpoint({"connection_type": "udpin", "place": "0.0.0.0", "argument": 14550})
+    Endpoint.is_mavlink_endpoint({"connection_type": "udpout", "place": "0.0.0.0", "argument": 14550})
     Endpoint.is_mavlink_endpoint({"connection_type": "serial", "place": "/dev/autopilot", "argument": 115200})
     Endpoint.is_mavlink_endpoint({"connection_type": "file", "place": "mavlink_dump"})
     with pytest.raises(ValueError):

--- a/core/services/ardupilot_manager/mavlink_proxy/test_all.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/test_all.py
@@ -28,7 +28,7 @@ def test_endpoint() -> None:
 
 
 def test_endpoint_validators() -> None:
-    Endpoint.is_mavlink_endpoint({"connection_type": "tcp", "place": "0.0.0.0", "argument": 14550})
+    Endpoint.is_mavlink_endpoint({"connection_type": "tcpin", "place": "0.0.0.0", "argument": 14550})
     Endpoint.is_mavlink_endpoint({"connection_type": "serial", "place": "/dev/autopilot", "argument": 115200})
     Endpoint.is_mavlink_endpoint({"connection_type": "file", "place": "mavlink_dump"})
     with pytest.raises(ValueError):

--- a/core/services/ardupilot_manager/mavlink_proxy/test_all.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/test_all.py
@@ -90,13 +90,28 @@ def test_mavlink_router() -> None:
     assert re.search(r"\d+", str(mavlink_router.version())) is not None, "Version does not follow pattern."
 
     endpoint_1 = Endpoint("udpout", "0.0.0.0", 14551)
-    endpoint_2 = Endpoint("udpout", "0.0.0.0", 14552)
+    endpoint_2 = Endpoint("tcpin", "0.0.0.0", 14552)
+    endpoint_3 = Endpoint("tcpout", "0.0.0.0", 14553)
     assert mavlink_router.add_endpoint(endpoint_1), "Failed to add first endpoint"
     assert mavlink_router.add_endpoint(endpoint_2), "Failed to add second endpoint"
+    assert mavlink_router.add_endpoint(endpoint_3), "Failed to add third endpoint"
     assert mavlink_router.endpoints() == [
         endpoint_1,
         endpoint_2,
+        endpoint_3,
     ], "Endpoint list does not match."
+    with pytest.raises(NotImplementedError):
+        mavlink_router.add_endpoint(Endpoint("udpin", "0.0.0.0", 14551))
+    with pytest.raises(NotImplementedError):
+        mavlink_router.add_endpoint(Endpoint("serial", "/dev/autopilot", 115200))
 
     assert mavlink_router.start(Endpoint("udpin", "0.0.0.0", 14550)), "Failed to start MAVLinkRouter"
     assert mavlink_router.is_running(), "MAVLinkRouter is not running after start."
+    assert mavlink_router.exit(), "MAVLinkRouter could not stop."
+    assert mavlink_router.start(Endpoint("serial", "/dev/autopilot", 115200)), "Failed to start MAVLinkRouter"
+    assert mavlink_router.is_running(), "MAVLinkRouter is not running after start."
+    assert mavlink_router.exit(), "MAVLinkRouter could not stop."
+    with pytest.raises(NotImplementedError):
+        mavlink_router.start(Endpoint("udpout", "0.0.0.0", 14550))
+    with pytest.raises(NotImplementedError):
+        mavlink_router.start(Endpoint("tcpout", "0.0.0.0", 14550))

--- a/core/services/ardupilot_manager/mavlink_proxy/test_all.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/test_all.py
@@ -63,17 +63,39 @@ def test_mavproxy() -> None:
     assert mavproxy.set_logdir(pathlib.Path(".")), "Local path as MAVProxy log directory failed."
     assert re.search(r"\d+.\d+.\d+", str(mavproxy.version())) is not None, "Version does not follow pattern."
 
-    endpoint_1 = Endpoint("udpout", "0.0.0.0", 14551)
+    endpoint_1 = Endpoint("udpin", "0.0.0.0", 14551)
     endpoint_2 = Endpoint("udpout", "0.0.0.0", 14552)
+    endpoint_3 = Endpoint("tcpin", "0.0.0.0", 14553)
+    endpoint_4 = Endpoint("tcpout", "0.0.0.0", 14554)
+    endpoint_5 = Endpoint("serial", "/dev/radiolink", 57600)
     assert mavproxy.add_endpoint(endpoint_1), "Failed to add first endpoint"
     assert mavproxy.add_endpoint(endpoint_2), "Failed to add second endpoint"
+    assert mavproxy.add_endpoint(endpoint_3), "Failed to add third endpoint"
+    assert mavproxy.add_endpoint(endpoint_4), "Failed to add fourth endpoint"
+    assert mavproxy.add_endpoint(endpoint_5), "Failed to add fifth endpoint"
     assert mavproxy.endpoints() == [
         endpoint_1,
         endpoint_2,
+        endpoint_3,
+        endpoint_4,
+        endpoint_5,
     ], "Endpoint list does not match."
 
+    assert mavproxy.start(Endpoint("udpin", "0.0.0.0", 14550)), "Failed to start mavproxy"
+    assert mavproxy.is_running(), "MAVProxy is not running after start."
+    assert mavproxy.exit(), "MAVProxy could not stop."
     assert mavproxy.start(Endpoint("udpout", "0.0.0.0", 14550)), "Failed to start mavproxy"
     assert mavproxy.is_running(), "MAVProxy is not running after start."
+    assert mavproxy.exit(), "MAVProxy could not stop."
+    assert mavproxy.start(Endpoint("tcpin", "0.0.0.0", 14550)), "Failed to start mavproxy"
+    assert mavproxy.is_running(), "MAVProxy is not running after start."
+    assert mavproxy.exit(), "MAVProxy could not stop."
+    assert mavproxy.start(Endpoint("tcpout", "0.0.0.0", 14550)), "Failed to start mavproxy"
+    assert mavproxy.is_running(), "MAVProxy is not running after start."
+    assert mavproxy.exit(), "MAVProxy could not stop."
+    assert mavproxy.start(Endpoint("serial", "/dev/autopilot", 115200)), "Failed to start mavproxy"
+    assert mavproxy.is_running(), "MAVProxy is not running after start."
+    assert mavproxy.exit(), "MAVProxy could not stop."
 
 
 def test_mavlink_router() -> None:

--- a/core/services/ardupilot_manager/settings.py
+++ b/core/services/ardupilot_manager/settings.py
@@ -13,7 +13,6 @@ class Settings:
     settings_path = Path(appdirs.user_config_dir(app_name))
     settings_file = Path.joinpath(settings_path, "settings.json")
     firmware_path = Path.joinpath(settings_path, "firmware")
-    file_endpoints_path = Path.joinpath(settings_path, "file_endpoints")
 
     def __init__(self) -> None:
         self.root: Dict[str, Union[int, Dict[str, Any]]] = {"version": 0, "content": {}}


### PR DESCRIPTION
- Allow for TCP client endpoints 
- Fix creation of serial endpoints on MAVProxy
- Fix validation for both MAVProxy and MavlinkRouter
- Simplify some syntax