### PR TITLE
Rename deploy action to "Build and Depĺoy Images"

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: deploy images
+name: Build and Deploy Images
 
 on:
     pull_request:


### PR DESCRIPTION
I'm always asking myself why a "deploy" action is running on a Pull Request.

(Yes, I used the github web interface to open this PR and I'm not ashamed)