### PR TITLE
Core: migrate to Python 3.9

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9] # Python 3.7 is the version in our buster image
+        python-version: [3.9] # Our base image has Python 3.9
 
     steps:
     -

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM python:3.9-slim-buster
 
 # Create default user folder
 RUN mkdir -p /home/pi
@@ -6,10 +6,6 @@ RUN mkdir -p /home/pi
 # Install gstreamer
 COPY install_gst.sh /install_gst.sh
 RUN GST_VERSION=1.17.2 ./install_gst.sh && rm /install_gst.sh
-
-# Install python3 and pip as default
-RUN apt install -y --no-install-recommends python3
-RUN ln -s /usr/bin/python3 /usr/bin/python
 
 # Install necessary tools
 COPY tools /home/pi/tools

--- a/core/tools/mavlink_router/bootstrap.py
+++ b/core/tools/mavlink_router/bootstrap.py
@@ -39,7 +39,8 @@ def run_apt_uninstall(package: str) -> None:
 
 
 print("Starting..")
-run_apt_install("autoconf g++ git libtool make pkg-config python3-future")
+run_apt_install("autoconf g++ git libtool make pkg-config")
+run_command("pip install future==0.18.2")
 
 set_directory(SERVICE_PATH)
 if not os.path.exists(MAVLINK_ROUTER_PATH):

--- a/core/tools/mavlink_router/bootstrap.py
+++ b/core/tools/mavlink_router/bootstrap.py
@@ -6,6 +6,8 @@ import sys
 CLONE_PATH = os.path.realpath("/tmp")
 SERVICE_PATH = os.path.dirname(os.path.realpath(__file__))
 MAVLINK_ROUTER_PATH = os.path.join(CLONE_PATH, "mavlink-router")
+# This commit is mavlink-router's master as of 05-22-2021
+MAVLINK_ROUTER_COMMIT = "94c4e3c6a9ff7c517b20b417e232caf52f12a6c6"
 
 
 def set_directory(path: str) -> None:
@@ -44,9 +46,11 @@ run_command("pip install future==0.18.2")
 
 set_directory(SERVICE_PATH)
 if not os.path.exists(MAVLINK_ROUTER_PATH):
-    run_command(f"git clone --depth 1 --branch v2 https://github.com/intel/mavlink-router {MAVLINK_ROUTER_PATH}")
+    run_command(f"git clone --depth 1 https://github.com/intel/mavlink-router {MAVLINK_ROUTER_PATH}")
 
 set_directory(MAVLINK_ROUTER_PATH)
+run_command(f"git fetch origin {MAVLINK_ROUTER_COMMIT}")
+run_command(f"git checkout {MAVLINK_ROUTER_COMMIT}")
 run_command("git submodule update --init --recursive --quiet")
 run_command("./autogen.sh")
 run_command(


### PR DESCRIPTION
Use williangalvani/companion-core:trespontonove to test.

startup.json for convenience:
```
{
    "core": {
        "tag": "trespontonove",
        "image": "williangalvani/companion-core",
        "enabled": true,
        "webui": false,
        "network": "host",
        "binds": {
            "/dev/": {
                "bind": "/dev/",
                "mode": "rw"
            },
            "/var/run/wpa_supplicant/wlan0": {
                "bind": "/var/run/wpa_supplicant/wlan0",
                "mode": "rw"
            },
            "/tmp/wpa_playground": {
                "bind": "/tmp/wpa_playground",
                "mode": "rw"
            }
        },
        "privileged": true
    }
}

```