### PR TITLE
Add linux2rest, a rest API + interface for system information 

### DIFF
--- a/bootstrap/startup.json.default
+++ b/bootstrap/startup.json.default
@@ -10,6 +10,10 @@
                 "bind": "/dev/",
                 "mode": "rw"
             },
+            "/sys/": {
+                "bind": "/sys/",
+                "mode": "r"
+            },
             "/var/run/wpa_supplicant/wlan0": {
                 "bind": "/var/run/wpa_supplicant/wlan0",
                 "mode": "rw"

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -15,6 +15,7 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 COPY tools /home/pi/tools
 RUN /home/pi/tools/mavlink_router/bootstrap.py
 RUN /home/pi/tools/mavlink_camera_manager/bootstrap.sh
+RUN /home/pi/tools/linux2rest/bootstrap.sh
 
 # Install necessary tools for basic usage
 RUN apt install -y file locate tmux unzip nano htop iputils-ping watch wget iproute2

--- a/core/start-companion-core
+++ b/core/start-companion-core
@@ -9,6 +9,7 @@ SERVICES=(
     'autopilot',"$SERVICES_PATH/ardupilot_manager/main.py"
     'helper',"$SERVICES_PATH/helper/main.py"
     'video',"mavlink-camera-manager --default-settings BlueROVUDP --verbose"
+    'linux2rest',"linux2rest"
 )
 
 tmux start-server

--- a/core/tools/linux2rest/bootstrap.sh
+++ b/core/tools/linux2rest/bootstrap.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+LOCAL_BINARY_PATH="/usr/bin/linux2rest"
+VERSION=v0.1.3
+
+# By default we install armv7
+REMOTE_BINARY_URL="https://github.com/patrickelectric/linux2rest/releases/download/${VERSION}/linux2rest-armv7"
+if [[ "$(uname -m)" == "x86_64"* ]]; then
+    REMOTE_BINARY_URL="https://github.com/patrickelectric/linux2rest/releases/download/${VERSION}/linux2rest-x86_64"
+fi
+
+# Download and install necessary libraries for linux2rest
+DEBIAN_FRONTEND=noninteractive apt --yes install wget libudev-dev
+wget "$REMOTE_BINARY_URL" -O "$LOCAL_BINARY_PATH"
+chmod +x "$LOCAL_BINARY_PATH"
+# Remove necessary stuff to install binary, creating a small docker layer
+## Some libraries are still necessary
+DEBIAN_FRONTEND=noninteractive apt --yes purge wget
+DEBIAN_FRONTEND=noninteractive apt --yes autoremove


### PR DESCRIPTION
Available under port 6030
To test: it's necessary to add the following bind in the bootstrap config:
```
"/sys/": {
    "bind": "/sys/",
    "mode": "r"
},
```
And use the following image:
`patrickelectric/companion-core:linux2rest`