### PR TITLE
Helper: help more

### DIFF
--- a/core/services/cable_guy/html/index.html
+++ b/core/services/cable_guy/html/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 
 <head>
+  <title>Cable-guy</title>
   <!-- Required meta tags -->
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">

--- a/core/services/helper/main.py
+++ b/core/services/helper/main.py
@@ -39,11 +39,11 @@ class Helper:
         info = ServiceInfo(valid=False, title="Unknown", ui="", port=port)
 
         try:
-            response = urlopen(f"http://127.0.0.1:{port}/", timeout=0.2)
-            info.valid = True
-            soup = BeautifulSoup(response.read(), features="html.parser")
-            title_element = soup.find("title")
-            info.title = title_element.text if title_element else "Unknown"
+            with urlopen(f"http://127.0.0.1:{port}/", timeout=0.2) as response:
+                info.valid = True
+                soup = BeautifulSoup(response.read(), features="html.parser")
+                title_element = soup.find("title")
+                info.title = title_element.text if title_element else "Unknown"
         except urllib.error.HTTPError as error:
             if error.code == http.HTTPStatus.NOT_FOUND:
                 info.valid = True

--- a/core/services/helper/main.py
+++ b/core/services/helper/main.py
@@ -2,31 +2,68 @@
 
 import http
 import urllib
+from dataclasses import dataclass
 from typing import List
 from urllib.request import urlopen
 
 import bottle
 import psutil
+from bs4 import BeautifulSoup
 
 PORT = 80
+DOCS_CANDIDATE_URLS = ["/v1.0/ui/", "/docs"]
+
+
+@dataclass
+class ServiceInfo:
+    valid: bool
+    title: str
+    ui: str
+    port: int
+
+    def as_html(self) -> str:
+        port_html = f"""
+        <a href="#" onclick="javascript:event.target.port={self.port}">{self.port}:</a>{self.title}
+        """
+        swagger_html = f"""
+        <a href="#" onclick="window.location.href = window.location.origin + ':' + {self.port} + '{self.ui}'">Open Api/Docs</a>
+        """
+        if self.ui:
+            return port_html + swagger_html
+        return port_html
 
 
 class Helper:
     @staticmethod
-    def check_webpage(port: int) -> bool:
+    def detect_service(port: int) -> ServiceInfo:
+        info = ServiceInfo(valid=False, title="Unknown", ui="", port=port)
+
         try:
-            urlopen(f"http://0.0.0.0:{port}/", timeout=0.2)
+            response = urlopen(f"http://127.0.0.1:{port}/", timeout=0.2)
+            info.valid = True
+            soup = BeautifulSoup(response.read(), features="html.parser")
+            title_element = soup.find("title")
+            info.title = title_element.text if title_element else "Unknown"
         except urllib.error.HTTPError as error:
             if error.code == http.HTTPStatus.NOT_FOUND:
-                return True
-            return False
+                info.valid = True
         except Exception as error:
-            return False
-        else:
-            return True
+            info.valid = False
+
+        if not info.valid:
+            return info
+
+        for ui_path in DOCS_CANDIDATE_URLS:
+            try:
+                urlopen(f"http://127.0.0.1:{port}{ui_path}", timeout=0.2)
+                info.ui = ui_path
+                break
+            except Exception as error:
+                pass  # any error here only means there's no ui available
+        return info
 
     @staticmethod
-    def get_webpage_ports() -> List[int]:
+    def scan_ports() -> List[ServiceInfo]:
         # Filter for TCP ports that are listen and can be accessed by external users (server in 0.0.0.0)
         connections = iter(psutil.net_connections("tcp"))
         connections = filter(lambda connection: connection.status == psutil.CONN_LISTEN, connections)
@@ -35,16 +72,16 @@ class Helper:
         # And check if there is a webpage available that is not us
         ports = iter([connection.laddr.port for connection in connections])
         ports = filter(lambda port: port != PORT, ports)
-        ports = filter(Helper.check_webpage, ports)
-
-        return list(ports)
+        services = map(Helper.detect_service, ports)
+        valid_services = filter(lambda service: service.valid, services)
+        return list(valid_services)
 
 
 if __name__ == "__main__":
 
     @bottle.route("/")
     def home() -> str:
-        ports = Helper.get_webpage_ports()
-        return r"<br>".join([f'<a href="/" onclick="javascript:event.target.port={port}">{port}</a>' for port in ports])
+        services = Helper.scan_ports()
+        return r"<br>".join([service.as_html() for service in services])
 
     bottle.run(host="0.0.0.0", port=PORT)

--- a/core/services/helper/main.py
+++ b/core/services/helper/main.py
@@ -8,7 +8,7 @@ from urllib.request import urlopen
 import bottle
 import psutil
 
-PORT = 8080
+PORT = 80
 
 
 class Helper:

--- a/core/services/helper/setup.py
+++ b/core/services/helper/setup.py
@@ -17,5 +17,6 @@ setup(
     install_requires=[
         "bottle == 0.12.19",
         "psutil == 5.7.2",
+        "beautifulsoup4 == 4.9.3",
     ],
 )

--- a/core/services/wifi/main.py
+++ b/core/services/wifi/main.py
@@ -7,6 +7,17 @@ from typing import Any, Dict, List, Union
 import bottle
 from wpa_supplicant import WPASupplicant
 
+BARE_HTML_TEMPLATE = """
+<html lang="en">
+<head>
+  <title>{title}</title>
+</head>
+<body>
+  {body}
+</body>
+</html>
+"""
+
 
 class WifiManager:
     wpa = WPASupplicant()
@@ -146,7 +157,9 @@ if __name__ == "__main__":
 
     @bottle.route("/")
     def home() -> str:
-        return r"<br>".join([f'<a href="{route.rule}">{route.rule}</a>' for route in bottle.app().routes])
+        body = r"<br>".join([f'<a href="{route.rule}">{route.rule}</a>' for route in bottle.app().routes])
+        page = BARE_HTML_TEMPLATE.format(title="Wifi Manager", body=body)
+        return page
 
     @bottle.route(REST_API_PREFIX + "/status")
     def status() -> bytes:


### PR DESCRIPTION
This extends the helper a little, trying to fetch the title of the service page and checking if swagger is available at /v1.0/ui:

![image](https://user-images.githubusercontent.com/4013804/115928598-c7be0e00-a45c-11eb-9034-de1338c38efc.png)
should I go ahead and format it with a table? :thinking: 

convenience startup.json:
```
{
    "core": {
        "tag": "morehelp",
        "image": "williangalvani/companion-core",
        "enabled": true,
        "webui": false,
        "network": "host",
        "binds": {
            "/dev/": {
                "bind": "/dev/",
                "mode": "rw"
            },
            "/var/run/wpa_supplicant/wlan0": {
                "bind": "/var/run/wpa_supplicant/wlan0",
                "mode": "rw"
            },
            "/tmp/wpa_playground": {
                "bind": "/tmp/wpa_playground",
                "mode": "rw"
            }
        },
        "privileged": true
    }
}
```

