### PR TITLE
gitignore: Update to include npm and cable-guy stuff

### DIFF
--- a/core/services/cable_guy/.gitignore
+++ b/core/services/cable_guy/.gitignore
@@ -1,0 +1,1 @@
+html/static/


### PR DESCRIPTION
The necessity to run eslint as part of the tests turned the npm install mandatory, and so what comes with it :sweat_smile: 

I'm also adding ignore for the static files generated by other services.