### PR TITLE
Bootstrap: use 'ro' for read-only bind on /sys

### DIFF
--- a/bootstrap/startup.json.default
+++ b/bootstrap/startup.json.default
@@ -12,7 +12,7 @@
             },
             "/sys/": {
                 "bind": "/sys/",
-                "mode": "r"
+                "mode": "ro"
             },
             "/var/run/wpa_supplicant/wlan0": {
                 "bind": "/var/run/wpa_supplicant/wlan0",


### PR DESCRIPTION
Fix #193 