### PR TITLE
CI: Eslint: enable 'no-extra-parens' rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,5 +16,6 @@ module.exports = {
     semi: ['error', 'never'],
     camelcase: [2, { properties: 'always' }],
     'space-before-function-paren': ['error', 'always'],
+    'no-extra-parens': ['error', 'all'],
   },
 }


### PR DESCRIPTION
This would have caught one error in the versionchooser pr

Check https://eslint.org/docs/rules/no-extra-parens