### PR TITLE
core: services: versionchooser: map both aarch64 and armv7l architectures to 'arm'

### DIFF
--- a/core/services/versionchooser/utils/dockerhub.py
+++ b/core/services/versionchooser/utils/dockerhub.py
@@ -14,7 +14,7 @@ import aiohttp
 
 def get_current_arch() -> str:
     """Maps paltform.machine() outputs to docker architectures"""
-    arch_map = {"x86_64": "amd64", "aarch64": "arm64", "armv7l": "arm32"}  # TODO: differentiate arm64v8/ arm32v7
+    arch_map = {"x86_64": "amd64", "aarch64": "arm", "armv7l": "arm"}  # TODO: differentiate arm64v8/ arm32v7
     machine = platform.machine()
     arch = arch_map.get(machine, None)
     if not arch:


### PR DESCRIPTION
This is what the API returns:
```
{'count': 1,
 'next': None,
 'previous': None,
 'results': [{'creator': 6451594,
              'full_size': 342651994,
              'id': 114550538,
              'image_id': None,
              'images': [{'architecture': 'arm',
                          'digest': 'sha256:8a9295ea8ecfa747ffd1ff79af552c5826275d2bf88124eb7071e75a3cdbab82',
                          'features': '',
                          'last_pulled': '2021-04-30T13:20:46.674809Z',
                          'last_pushed': '2021-04-28T21:38:30.628226Z',
                          'os': 'linux',
                          'os_features': '',
                          'os_version': None,
                          'size': 314955078,
                          'status': 'active',
                          'variant': 'v7'},
                         {'architecture': 'amd64',
                          'digest': 'sha256:c877a4d62e8146041992228dfa5f6b0a1892eb441794f34c445ff4ce1ba78a9c',
                          'features': '',
                          'last_pulled': '2021-04-30T13:25:57.299851Z',
                          'last_pushed': '2021-04-28T20:10:38.254056Z',
                          'os': 'linux',
                          'os_features': '',
                          'os_version': None,
                          'size': 342651994,
                          'status': 'active',
                          'variant': None}],
              'last_updated': '2021-04-28T21:38:31.053798Z',
              'last_updater': 6451594,
              'last_updater_username': 'bluerobotics',
              'name': 'master',
              'repository': 9696866,
              'tag_last_pulled': '2021-04-30T13:25:57.299851Z',
              'tag_last_pushed': '2021-04-28T21:38:31.053798Z',
              'tag_status': 'active',
              'v2': True}]}
```

Later on we could filter the variant, too, to support different boards.