### PR TITLE
CI: use the dockerfile hash instead of commit sha to cache dockers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,7 +67,7 @@ jobs:
         id: cache
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ matrix.docker }}-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-${{ matrix.docker }}-${{ hashFiles(format('{0}/Dockerfile', matrix.docker)) }}
           restore-keys: |
             ${{ runner.os }}-buildx-${{ matrix.docker }}
       -


### PR DESCRIPTION
If we use a different key each time we run, we can't get any cache hits:

![image](https://user-images.githubusercontent.com/4013804/117338189-a7d31500-ae74-11eb-9991-4f93e9d84891.png)

we should just cache based on the image name  and let buildx decide if it is a hit or a miss.