### PR TITLE
eslint: Remove camelcase check

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,6 @@ module.exports = {
     'object-shorthand': 'error',
     'prefer-const': 'error',
     'space-before-function-paren': ['error', 'always'],
-    camelcase: [2, { properties: 'never' }],
     indent: ['error', 2],
     quotes: ['error', 'single'],
     semi: ['error', 'never'],


### PR DESCRIPTION
Even when using `{ properties: 'never' }`, camelcase check will blame on function arguments not using camelcase, so we need to completely remove this check.