### PR TITLE
Bootstrap: fix docker dependency to 5.0.0

### DIFF
--- a/bootstrap/bootstrap/setup.py
+++ b/bootstrap/bootstrap/setup.py
@@ -7,7 +7,5 @@ setup(
     version="0.0.1",
     description="Blue Robotics Ardusub Companion Docker System Bootstrap",
     license="MIT",
-    install_requires=[
-        "docker",
-    ],
+    install_requires=["docker == 5.0.0", "six == 1.15.0"],
 )


### PR DESCRIPTION
These are all packages in the working container I have here:
```
certifi==2020.12.5
chardet==4.0.0
companion-bootstrap==0.0.1
docker==5.0.0
idna==2.10
requests==2.25.1
six==1.15.0
urllib3==1.26.4
websocket-client==0.58.0
```

locking "docker" and adding "six"(why was it missing?) seems to fix the issue.
I'll leave the list here in case we need to fix more stuff in the future.

Fix #241 