### PR TITLE
Fix rpi-update 

### DIFF
--- a/install/boards/bcm_27xx.sh
+++ b/install/boards/bcm_27xx.sh
@@ -70,5 +70,5 @@ sudo sed -e 's/console=serial[0-9],[0-9]*\ //' -i /boot/cmdline.txt
 # on older firmware versions
 if grep -q ID=raspbian < /etc/os-release; then
     echo "- Run rpi update."
-    sudo rpi-update 1340be4
+    sudo SKIP_WARNING=1 rpi-update 1340be4
 fi

--- a/install/boards/bcm_27xx.sh
+++ b/install/boards/bcm_27xx.sh
@@ -69,6 +69,11 @@ sudo sed -e 's/console=serial[0-9],[0-9]*\ //' -i /boot/cmdline.txt
 # this is required to avoid 'i2c transfer timed out' kernel errors
 # on older firmware versions
 if grep -q ID=raspbian < /etc/os-release; then
-    echo "- Run rpi update."
-    sudo SKIP_WARNING=1 rpi-update 1340be4
+    RPI_FIRMWARE_VERSION=1340be4
+    if sudo JUST_CHECK=1 rpi-update $RPI_FIRMWARE_VERSION | grep "Firmware update required"; then
+        echo "- Run rpi update."
+        sudo SKIP_WARNING=1 rpi-update $RPI_FIRMWARE_VERSION
+    else
+        echo "- Firmware is up to date."
+    fi
 fi


### PR DESCRIPTION
Fix #245

```
onfiguring BCM27XX board (Raspberry Pi 4)..
- compile spi0 device tree overlay.
- Enable I2C, SPI and UART.
enable_uart=1
dtoverlay=uart1
dtoverlay=uart3
dtoverlay=uart4
dtoverlay=uart5
dtparam=i2c_vc=on
dtoverlay=i2c1
dtoverlay=i2c4,pins_6_7
dtoverlay=i2c6,pins_22_23
dtparam=spi=on
dtoverlay=spi0-led
dtoverlay=spi1-3cs
gpio=11,24,25=op,pu,dh
gpio=37=op,pd,dl
- Set up kernel modules.
bcm2835-v4l2
i2c-bcm2835
i2c-dev
- Configure serial.
- Firmware is up to date.
pi@companion:~ $ echo "$?"
0
```

It fixes the problem and add an extra test to make sure that the firmware needs an update. 