### PR TITLE
core: versionchooser: use 'fat manifest' to fetch the correct image digest on all architectures

### DIFF
--- a/core/services/versionchooser/utils/dockerhub.py
+++ b/core/services/versionchooser/utils/dockerhub.py
@@ -66,17 +66,39 @@ class TagFetcher:
                     raise Exception("Could not get auth token")
                 return str((await resp.json())["token"])
 
+    async def get_digest(self, metadata: TagMetadata) -> str:
+        """Fetches the digest for this architecture for a given tag"""
+        header = {
+            "Authorization": f"Bearer {self.last_token}",
+            "Accept": "application/vnd.docker.distribution.manifest.list.v2+json",
+        }
+
+        arch = get_current_arch()
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                f"{self.index_url}/v2/{metadata.repository}/manifests/{metadata.tag}", headers=header
+            ) as resp:
+                if resp.status != 200:
+                    raise Exception(f"Failed getting sha from DockerHub! bad response: {resp.status}")
+                data = await resp.json()
+                manifests = data["manifests"]
+                matching_manifest = list(filter(lambda x: x["platform"]["architecture"] == arch, manifests))
+                if not matching_manifest:
+                    raise Exception(f"Failed getting sha from DockerHub: {metadata.tag} is missing architecture {arch}")
+                digest: str = matching_manifest[0]["digest"]
+                return digest
+
     async def fetch_sha(self, metadata: TagMetadata) -> str:
         """Fetches the digest sha from a tag"""
         header = {
             "Authorization": f"Bearer {self.last_token}",
             "Accept": "application/vnd.docker.distribution.manifest.v2+json",
         }
-        tag = metadata.tag
 
+        digest = await self.get_digest(metadata)
         async with aiohttp.ClientSession() as session:
             async with session.get(
-                f"{self.index_url}/v2/{metadata.repository}/manifests/{tag}", headers=header
+                f"{self.index_url}/v2/{metadata.repository}/manifests/{digest}", headers=header
             ) as resp:
                 if resp.status != 200:
                     warn(f"Error status {resp.status}")


### PR DESCRIPTION
Previously, the arm builds were showing the remote sha of the x86
images. This fixes that issue by first using the "fat manifest" to get the digest of the correct architecture, and then 

More information at https://docs.docker.com/registry/spec/manifest-v2-2/

helps #267 

(crap. wrong remote)