### PR TITLE
core: tools: bridges: don't (un)install wget

### DIFF
--- a/core/tools/bridges/bootstrap.sh
+++ b/core/tools/bridges/bootstrap.sh
@@ -9,10 +9,5 @@ if [[ "$(uname -m)" == "x86_64"* ]]; then
     REMOTE_BINARY_URL="https://github.com/patrickelectric/bridges/releases/download/${VERSION}/bridges-x86_64-unknown-linux-musl"
 fi
 
-DEBIAN_FRONTEND=noninteractive apt --yes install wget
 wget "$REMOTE_BINARY_URL" -O "$LOCAL_BINARY_PATH"
 chmod +x "$LOCAL_BINARY_PATH"
-# Remove necessary stuff to install binary, creating a small docker layer
-## Some libraries are still necessary
-DEBIAN_FRONTEND=noninteractive apt --yes purge wget
-DEBIAN_FRONTEND=noninteractive apt --yes autoremove


### PR DESCRIPTION
wget is one of the basic tools [installed in companion-base](https://github.com/bluerobotics/companion-docker-base/blob/master/Dockerfile#L11).
it shouldn't be uninstalled or reinstalled in core.