### PR TITLE
Core: versionchooser: only start polling the backend once we change the running image

### DIFF
--- a/core/services/versionchooser/static/index.html
+++ b/core/services/versionchooser/static/index.html
@@ -138,7 +138,6 @@
         Metro.init()
         this.Metro = Metro
         this.loadCurrentVersion()
-        setInterval(this.checkIfBackendIsOnline, 1000)
       },
       methods: {
         checkIfBackendIsOnline () {
@@ -243,7 +242,7 @@
               repository,
               tag,
             },
-          })
+          }).finally(() => setInterval(this.checkIfBackendIsOnline, 1000))
         },
         imageIsAvailableLocally (sha) {
           if (!('local' in this.availableVersions)) {


### PR DESCRIPTION
Previously there was a race condition that made the webpage refresh before the
backend came back online (showing "server offline"). This fixes that.