### PR TITLE
Add SITL to ArduPilot Manager

### DIFF
--- a/core/services/ardupilot_manager/ArduPilotManager.py
+++ b/core/services/ardupilot_manager/ArduPilotManager.py
@@ -8,7 +8,7 @@ from typing import Any, List, Optional, Set, Tuple
 
 from loguru import logger
 
-from firmware_download.FirmwareDownload import FirmwareDownload, Vehicle
+from firmware_download.FirmwareDownload import FirmwareDownload, Platform, Vehicle
 from flight_controller_detector.Detector import Detector as BoardDetector
 from flight_controller_detector.Detector import FlightControllerType
 from mavlink_proxy.Endpoint import Endpoint
@@ -49,7 +49,7 @@ class ArduPilotManager(metaclass=Singleton):
     def start_navigator(self) -> None:
         firmware = os.path.join(self.settings.firmware_path, "ardusub")
         if not os.path.isfile(firmware):
-            temporary_file = self.firmware_download.download(Vehicle.Sub, "Navigator")
+            temporary_file = self.firmware_download.download(Vehicle.Sub, Platform.Navigator)
             assert temporary_file, "Failed to download navigator binary."
             shutil.move(str(temporary_file), firmware)
             # Make the binary executable

--- a/core/services/ardupilot_manager/firmware_download/FirmwareDownload.py
+++ b/core/services/ardupilot_manager/firmware_download/FirmwareDownload.py
@@ -6,7 +6,7 @@ import random
 import ssl
 import string
 import tempfile
-from enum import IntEnum
+from enum import Enum
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
 from urllib.request import urlopen, urlretrieve
@@ -20,13 +20,13 @@ if not os.environ.get("PYTHONHTTPSVERIFY", "") and getattr(ssl, "_create_unverif
     ssl._create_default_https_context = ssl._create_unverified_context
 
 
-class Vehicle(IntEnum):
+class Vehicle(str, Enum):
     """Valid vehicle types to download"""
 
-    Sub = 1
-    Rover = 2
-    Plane = 3
-    Copter = 4
+    Sub = "Sub"
+    Rover = "Rover"
+    Plane = "Plane"
+    Copter = "Copter"
 
 
 class FirmwareDownload:
@@ -174,7 +174,7 @@ class FirmwareDownload:
             return available_versions
 
         items = self._find_version_item(
-            vehicletype=vehicle.name, platform=platform, format=FirmwareDownload._supported_firmware_format
+            vehicletype=vehicle.value, platform=platform, format=FirmwareDownload._supported_firmware_format
         )
 
         for item in items:
@@ -214,7 +214,7 @@ class FirmwareDownload:
             version = f"STABLE-{newest_version}"
 
         items = self._find_version_item(
-            vehicletype=vehicle.name,
+            vehicletype=vehicle.value,
             platform=platform,
             mav_firmware_version_type=version,
             format=FirmwareDownload._supported_firmware_format,

--- a/core/services/ardupilot_manager/firmware_download/FirmwareDownload.py
+++ b/core/services/ardupilot_manager/firmware_download/FirmwareDownload.py
@@ -29,6 +29,15 @@ class Vehicle(str, Enum):
     Copter = "Copter"
 
 
+class Platform(str, Enum):
+    """Valid platform types to download
+    The Enum values are 1:1 representations of the platforms available on the ArduPilot manifest,
+    with the exception being Navigator, which is not on the manifest yet."""
+
+    Pixhawk1 = "Pixhawk1"
+    Navigator = "Navigator"
+
+
 class FirmwareDownload:
     _manifest_remote = "https://firmware.ardupilot.org/manifest.json.gz"
     _supported_firmware_format = "apj"
@@ -158,12 +167,12 @@ class FirmwareDownload:
 
         return found_version_item
 
-    def get_available_versions(self, vehicle: Vehicle, platform: str) -> List[str]:
+    def get_available_versions(self, vehicle: Vehicle, platform: Platform) -> List[str]:
         """Get available firmware versions for the specific plataform and vehicle
 
         Args:
             vehicle (Vehicle): Desired vehicle.
-            platform (str): Desired platform.
+            platform (Platform): Desired platform.
 
         Returns:
             List[str]: List of available versions that match the specific desired configuration.
@@ -174,7 +183,7 @@ class FirmwareDownload:
             return available_versions
 
         items = self._find_version_item(
-            vehicletype=vehicle.value, platform=platform, format=FirmwareDownload._supported_firmware_format
+            vehicletype=vehicle.value, platform=platform.value, format=FirmwareDownload._supported_firmware_format
         )
 
         for item in items:
@@ -182,19 +191,19 @@ class FirmwareDownload:
 
         return available_versions
 
-    def download(self, vehicle: Vehicle, platform: str, version: str = "") -> Optional[pathlib.Path]:
+    def download(self, vehicle: Vehicle, platform: Platform, version: str = "") -> Optional[pathlib.Path]:
         """Download a specific firmware that matches the arguments.
 
         Args:
             vehicle (Vehicle): Desired vehicle.
-            platform (str): Desired platform.
+            platform (Platform): Desired platform.
             version (str, optional): Desired version, if None provided the latest stable will be used.
                 Defaults to None.
 
         Returns:
             Optional[pathlib.Path]: Temporary path for the firmware file, None if unable to download or validate file.
         """
-        if platform.lower() == "navigator" and vehicle == Vehicle.Sub:
+        if platform == Platform.Navigator and vehicle == Vehicle.Sub:
             return FirmwareDownload._download_navigator()
 
         versions = self.get_available_versions(vehicle, platform)
@@ -215,7 +224,7 @@ class FirmwareDownload:
 
         items = self._find_version_item(
             vehicletype=vehicle.value,
-            platform=platform,
+            platform=platform.value,
             mav_firmware_version_type=version,
             format=FirmwareDownload._supported_firmware_format,
         )

--- a/core/services/ardupilot_manager/firmware_download/test_FirmwareDownload.py
+++ b/core/services/ardupilot_manager/firmware_download/test_FirmwareDownload.py
@@ -1,4 +1,4 @@
-from firmware_download.FirmwareDownload import FirmwareDownload, Vehicle
+from firmware_download.FirmwareDownload import FirmwareDownload, Platform, Vehicle
 
 
 def test_static() -> None:
@@ -15,16 +15,16 @@ def test_firmware_download() -> None:
     assert firmware_download.download_manifest(), "Failed to download/validate manifest file."
 
     versions = firmware_download._find_version_item(
-        vehicletype="Sub", format="apj", mav_firmware_version_type="STABLE-4.0.1", platform="Pixhawk1"
+        vehicletype="Sub", format="apj", mav_firmware_version_type="STABLE-4.0.1", platform=Platform.Pixhawk1
     )
     assert len(versions) == 1, "Failed to find a single firmware."
 
     versions = firmware_download._find_version_item(
-        vehicletype="Sub", mav_firmware_version_type="STABLE-4.0.1", platform="Pixhawk1"
+        vehicletype="Sub", mav_firmware_version_type="STABLE-4.0.1", platform=Platform.Pixhawk1
     )
     assert len(versions) == 3, "Failed to find multiple versions."
 
-    available_versions = firmware_download.get_available_versions(Vehicle.Sub, "Pixhawk1")
+    available_versions = firmware_download.get_available_versions(Vehicle.Sub, Platform.Pixhawk1)
     assert len(available_versions) == len(set(available_versions)), "Available versions are not unique."
 
     test_available_versions = ["STABLE-4.0.1", "STABLE-4.0.0", "OFFICIAL", "DEV", "BETA"]
@@ -33,9 +33,9 @@ def test_firmware_download() -> None:
     ), "Available versions are missing know versions."
 
     assert firmware_download.download(
-        Vehicle.Sub, "Pixhawk1", "STABLE-4.0.1"
+        Vehicle.Sub, Platform.Pixhawk1, "STABLE-4.0.1"
     ), "Failed to download a valid firmware file."
 
-    assert firmware_download.download(Vehicle.Sub, "Pixhawk1"), "Failed to download latest valid firmware file."
+    assert firmware_download.download(Vehicle.Sub, Platform.Pixhawk1), "Failed to download latest valid firmware file."
 
-    assert firmware_download.download(Vehicle.Sub, "Navigator"), "Failed to download navigator binary."
+    assert firmware_download.download(Vehicle.Sub, Platform.Navigator), "Failed to download navigator binary."

--- a/core/services/ardupilot_manager/main.py
+++ b/core/services/ardupilot_manager/main.py
@@ -1,4 +1,5 @@
 #! /usr/bin/env python3
+import argparse
 import json
 import logging
 from pathlib import Path
@@ -15,6 +16,11 @@ from ArduPilotManager import ArduPilotManager
 from mavlink_proxy.Endpoint import Endpoint
 
 FRONTEND_FOLDER = Path.joinpath(Path(__file__).parent.absolute(), "frontend")
+
+parser = argparse.ArgumentParser(description="ArduPilot Manager service for Blue Robotics Companion")
+parser.add_argument("-s", "--sitl", help="run SITL instead of connecting any board", action="store_true")
+
+args = parser.parse_args()
 
 
 class InterceptHandler(logging.Handler):
@@ -91,6 +97,9 @@ app.mount("/", StaticFiles(directory=str(FRONTEND_FOLDER), html=True))
 
 
 if __name__ == "__main__":
-    autopilot.run()
+    if args.sitl:
+        autopilot.run_with_sitl()
+    else:
+        autopilot.run_with_board()
     # Running uvicorn with log disabled so loguru can handle it
     uvicorn.run(app, host="0.0.0.0", port=8000, log_config=None)

--- a/core/services/ardupilot_manager/mavlink_proxy/MAVLinkRouter.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/MAVLinkRouter.py
@@ -60,7 +60,8 @@ class MAVLinkRouter(AbstractRouter):
         log = f"--log {self.logdir().resolve()}"
 
         if master.connection_type == EndpointType.TCPServer:
-            return f"{self.binary()} --tcp-port {master.argument} {log} {endpoints}"
+            # The "--tcp-port 0" argument is used to prevent the router from binding TCP port 5760
+            return f"{self.binary()} --tcp-endpoint {master.place}:{master.argument} --tcp-port 0 {log} {endpoints}"
 
         return f"{self.binary()} {master.place}:{master.argument} --tcp-port 0 {log} {endpoints}"
 

--- a/core/services/ardupilot_manager/mavlink_proxy/MAVProxy.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/MAVProxy.py
@@ -37,6 +37,8 @@ class MAVProxy(AbstractRouter):
                 master_string = f"{master.place}"
             else:
                 master_string = f"{serial_endpoint_as_input(master)}"
+        if master.connection_type == EndpointType.TCPServer:
+            master_string = f"tcp:{master.place}:{master.argument}"
 
         log = f"--state-basedir={self.logdir().resolve()}"
         return f"{self.binary()} --master={master_string} {endpoints} {log} --non-interactive"

--- a/core/services/ardupilot_manager/mavlink_proxy/test_all.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/test_all.py
@@ -19,27 +19,27 @@ from mavlink_proxy.MAVProxy import MAVProxy
 @pytest.fixture
 def valid_output_endpoints() -> Set[Endpoint]:
     return {
-        Endpoint("Test endpoint 1", "pytest", "udpin", "0.0.0.0", 14551),
-        Endpoint("Test endpoint 2", "pytest", "udpout", "0.0.0.0", 14552),
-        Endpoint("Test endpoint 3", "pytest", "tcpin", "0.0.0.0", 14553),
-        Endpoint("Test endpoint 4", "pytest", "tcpout", "0.0.0.0", 14554),
-        Endpoint("Test endpoint 5", "pytest", "serial", "/dev/radiolink", 57600),
+        Endpoint("Test endpoint 1", "pytest", EndpointType.UDPServer, "0.0.0.0", 14551),
+        Endpoint("Test endpoint 2", "pytest", EndpointType.UDPClient, "0.0.0.0", 14552),
+        Endpoint("Test endpoint 3", "pytest", EndpointType.TCPServer, "0.0.0.0", 14553),
+        Endpoint("Test endpoint 4", "pytest", EndpointType.TCPClient, "0.0.0.0", 14554),
+        Endpoint("Test endpoint 5", "pytest", EndpointType.Serial, "/dev/radiolink", 57600),
     }
 
 
 @pytest.fixture
 def valid_master_endpoints() -> Set[Endpoint]:
     return {
-        Endpoint("Master endpoint 1", "pytest", "udpin", "0.0.0.0", 14550),
-        Endpoint("Master endpoint 2", "pytest", "udpout", "0.0.0.0", 14550),
-        Endpoint("Master endpoint 3", "pytest", "tcpin", "0.0.0.0", 14550),
-        Endpoint("Master endpoint 4", "pytest", "tcpout", "0.0.0.0", 14550),
-        Endpoint("Master endpoint 5", "pytest", "serial", "/dev/autopilot", 115200),
+        Endpoint("Master endpoint 1", "pytest", EndpointType.UDPServer, "0.0.0.0", 14550),
+        Endpoint("Master endpoint 2", "pytest", EndpointType.UDPClient, "0.0.0.0", 14550),
+        Endpoint("Master endpoint 3", "pytest", EndpointType.TCPServer, "0.0.0.0", 14550),
+        Endpoint("Master endpoint 4", "pytest", EndpointType.TCPClient, "0.0.0.0", 14550),
+        Endpoint("Master endpoint 5", "pytest", EndpointType.Serial, "/dev/autopilot", 115200),
     }
 
 
 def test_endpoint() -> None:
-    endpoint = Endpoint("Test endpoint", "pytest", "udpout", "0.0.0.0", 14550)
+    endpoint = Endpoint("Test endpoint", "pytest", EndpointType.UDPClient, "0.0.0.0", 14550)
     assert endpoint.name == "Test endpoint", "Name does not match."
     assert endpoint.owner == "pytest", "Owner does not match."
     assert endpoint.persistent is False, "Persistent does not match."
@@ -51,7 +51,7 @@ def test_endpoint() -> None:
     assert endpoint.asdict() == {
         "name": "Test endpoint",
         "owner": "pytest",
-        "connection_type": "udpout",
+        "connection_type": EndpointType.UDPClient,
         "place": "0.0.0.0",
         "argument": 14550,
         "persistent": False,
@@ -61,13 +61,17 @@ def test_endpoint() -> None:
 
 def test_endpoint_validators() -> None:
     with pytest.raises(ValueError):
-        Endpoint.is_mavlink_endpoint({"connection_type": "udpin", "place": "0.0.0.0", "argument": -30})
+        Endpoint.is_mavlink_endpoint({"connection_type": EndpointType.UDPServer, "place": "0.0.0.0", "argument": -30})
     with pytest.raises(ValueError):
-        Endpoint.is_mavlink_endpoint({"connection_type": "udpin", "place": "42", "argument": 14555})
+        Endpoint.is_mavlink_endpoint({"connection_type": EndpointType.UDPServer, "place": "42", "argument": 14555})
     with pytest.raises(ValueError):
-        Endpoint.is_mavlink_endpoint({"connection_type": "serial", "place": "dev/autopilot", "argument": 115200})
+        Endpoint.is_mavlink_endpoint(
+            {"connection_type": EndpointType.Serial, "place": "dev/autopilot", "argument": 115200}
+        )
     with pytest.raises(ValueError):
-        Endpoint.is_mavlink_endpoint({"connection_type": "serial", "place": "/dev/autopilot", "argument": 100000})
+        Endpoint.is_mavlink_endpoint(
+            {"connection_type": EndpointType.Serial, "place": "/dev/autopilot", "argument": 100000}
+        )
     with pytest.raises(ValueError):
         Endpoint.is_mavlink_endpoint({"connection_type": "potato", "place": "path/to/file", "argument": 100})
 


### PR DESCRIPTION
Fix #98 

Use `--sitl` to activate it.

When [this PR](https://github.com/ArduPilot/ardupilot/pull/17573) gets approved we should reintroduce validation of the SITL binary.

~~Missing tests with Rasp/Navigator.~~
Tested with x86 and ARMv7 platforms.