### PR TITLE
Add get_download_url to abstract urls for firmware download

### DIFF
--- a/core/services/ardupilot_manager/firmware_download/FirmwareDownload.py
+++ b/core/services/ardupilot_manager/firmware_download/FirmwareDownload.py
@@ -237,7 +237,11 @@ class FirmwareDownload:
         versions = self.get_available_versions(vehicle, platform)
         logger.debug(f"Got following versions for {vehicle} running {platform}: {versions}")
 
-        if version and versions and version not in versions:
+        if not versions:
+            logger.error("No versions available")
+            return None
+
+        if version and version not in versions:
             logger.error(f"Specified version not found for this configuration ({vehicle} and {platform}).")
             return None
 

--- a/core/services/ardupilot_manager/firmware_download/test_FirmwareDownload.py
+++ b/core/services/ardupilot_manager/firmware_download/test_FirmwareDownload.py
@@ -1,3 +1,5 @@
+import os
+
 from firmware_download.FirmwareDownload import FirmwareDownload, Platform, Vehicle
 
 
@@ -38,4 +40,12 @@ def test_firmware_download() -> None:
 
     assert firmware_download.download(Vehicle.Sub, Platform.Pixhawk1), "Failed to download latest valid firmware file."
 
-    assert firmware_download.download(Vehicle.Sub, Platform.Navigator), "Failed to download navigator binary."
+    # It'll fail if running in an arch different of ARM
+    if "x86" in os.uname().machine:
+        assert (
+            firmware_download.download(Vehicle.Sub, Platform.Navigator) is None
+        ), "Failed to download navigator binary."
+    else:
+        assert (
+            firmware_download.download(Vehicle.Sub, Platform.Navigator) is not None
+        ), "Failed to download navigator binary."


### PR DESCRIPTION
Fix #303
Alternative to #304 

Adds a function to find the correct URL to download, this allow us to have magic urls for specific products if a desired combination is valid. Also unifies the validation and permission between such options.