### PR TITLE
core: ardupilot_manager: map serial ports to ardusub's ports

### DIFF
--- a/core/services/ardupilot_manager/ArduPilotManager.py
+++ b/core/services/ardupilot_manager/ArduPilotManager.py
@@ -61,11 +61,26 @@ class ArduPilotManager(metaclass=Singleton):
         ## Can be changed back to a simple command after https://github.com/ArduPilot/ardupilot/issues/17572
         ## gets fixed.
         # pylint: disable=consider-using-with
+        #
+        # The mapping of serial ports works as in the following table:
+        #
+        # |    ArduSub   |       Navigator         |
+        # | -C = Serial1 | Serial1 => /dev/ttyS0   |
+        # | -B = Serial3 | Serial3 => /dev/ttyAMA1 |
+        # | -E = Serial4 | Serial4 => /dev/ttyAMA2 |
+        # | -F = Serial5 | Serial5 => /dev/ttyAMA3 |
+        #
+        # The first column comes from https://ardupilot.org/dev/docs/sitl-serial-mapping.html
+
         self.subprocess = subprocess.Popen(
             "while true; do "
             f"{firmware} -A udp:{master_endpoint.place}:{master_endpoint.argument}"
             f" --log-directory {self.settings.firmware_path}/logs/"
             f" --storage-directory {self.settings.firmware_path}/storage/"
+            f" -C /dev/ttyS0"
+            f" -B /dev/ttyAMA1"
+            f" -E /dev/ttyAMA2"
+            f" -F /dev/ttyAMA3"
             "; sleep 1; done",
             shell=True,
             encoding="utf-8",

--- a/core/services/ardupilot_manager/ArduPilotManager.py
+++ b/core/services/ardupilot_manager/ArduPilotManager.py
@@ -105,6 +105,14 @@ class ArduPilotManager(metaclass=Singleton):
         master_endpoint = Endpoint(
             "Master", self.settings.app_name, EndpointType.TCPServer, "127.0.0.1", 5760, protected=True
         )
+        # The mapping of serial ports works as in the following table:
+        #
+        # |    ArduSub   |       Navigator         |
+        # | -C = Serial1 | Serial1 => /dev/ttyS0   |
+        # | -B = Serial3 | Serial3 => /dev/ttyAMA1 |
+        # | -E = Serial4 | Serial4 => /dev/ttyAMA2 |
+        # | -F = Serial5 | Serial5 => /dev/ttyAMA3 |
+        #
         # pylint: disable=consider-using-with
         self.subprocess = subprocess.Popen(
             [
@@ -115,6 +123,14 @@ class ArduPilotManager(metaclass=Singleton):
                 str(master_endpoint.argument),
                 "--home",
                 "-27.563,-48.459,0.0,270.0",
+                "-C",
+                "/dev/ttyS0",
+                "-B",
+                "/dev/ttyAMA1",
+                "-E",
+                "/dev/ttyAMA2",
+                "-F",
+                "/dev/ttyAMA3",
             ],
             shell=False,
             encoding="utf-8",


### PR DESCRIPTION
Tested with an ublox GPS.
Ardusub didn't like the gps on ports other than SERIAL1, so I made all of them serial1 individually to test.
This should allow us to use serial... stuff.

the mapping comes from correlating our the navigtor mapping:
![image](https://user-images.githubusercontent.com/4013804/121061206-f1778e00-c799-11eb-92ad-f8a2211660ff.png)

With these docs:
https://ardupilot.org/dev/docs/sitl-serial-mapping.html