### PR TITLE
core: ardupilot_manager: Fix ELF permission

### DIFF
--- a/core/services/ardupilot_manager/firmware_download/FirmwareDownload.py
+++ b/core/services/ardupilot_manager/firmware_download/FirmwareDownload.py
@@ -300,6 +300,10 @@ class FirmwareDownload:
 
         path = FirmwareDownload._download(url)
 
+        if not path:
+            logger.error("Failed to download firmware.")
+            return None
+
         firmware_format = FirmwareDownload._supported_firmware_formats[platform]
         if firmware_format == FirmwareFormat.ELF:
             # Make the binary executable
@@ -310,7 +314,7 @@ class FirmwareDownload:
             ## For more information: https://www.gnu.org/software/libc/manual/html_node/Permission-Bits.html
             path.chmod(path.stat().st_mode | stat.S_IXOTH | stat.S_IXUSR | stat.S_IXGRP)
 
-        if not path or not FirmwareDownload._validate_firmware(path):
+        if not FirmwareDownload._validate_firmware(path):
             logger.error("Unable to validate firmware file.")
             return None
 

--- a/core/services/ardupilot_manager/firmware_download/FirmwareDownload.py
+++ b/core/services/ardupilot_manager/firmware_download/FirmwareDownload.py
@@ -97,6 +97,7 @@ class FirmwareDownload:
         name = pathlib.Path(urlparse(url).path).name
         filename = pathlib.Path(f"{FirmwareDownload._generate_random_filename()}-{name}")
         try:
+            logger.debug(f"Downloading: {url}")
             urlretrieve(url, filename)
         except Exception as error:
             logger.error(f"Failed to download {url}: {error}")

--- a/core/services/ardupilot_manager/firmware_download/FirmwareDownload.py
+++ b/core/services/ardupilot_manager/firmware_download/FirmwareDownload.py
@@ -303,7 +303,12 @@ class FirmwareDownload:
         firmware_format = FirmwareDownload._supported_firmware_formats[platform]
         if firmware_format == FirmwareFormat.ELF:
             # Make the binary executable
-            os.chmod(str(path), stat.S_IXOTH)
+            ## S_IX: Execution permission for
+            ##    OTH: Others
+            ##    USR: User
+            ##    GRP: Group
+            ## For more information: https://www.gnu.org/software/libc/manual/html_node/Permission-Bits.html
+            path.chmod(path.stat().st_mode | stat.S_IXOTH | stat.S_IXUSR | stat.S_IXGRP)
 
         if not path or not FirmwareDownload._validate_firmware(path):
             logger.error("Unable to validate firmware file.")

--- a/core/services/ardupilot_manager/firmware_download/test_FirmwareDownload.py
+++ b/core/services/ardupilot_manager/firmware_download/test_FirmwareDownload.py
@@ -40,6 +40,8 @@ def test_firmware_download() -> None:
 
     assert firmware_download.download(Vehicle.Sub, Platform.Pixhawk1), "Failed to download latest valid firmware file."
 
+    assert firmware_download.download(Vehicle.Sub, Platform.SITL), "Failed to download SITL."
+
     # It'll fail if running in an arch different of ARM
     if "x86" in os.uname().machine:
         assert (


### PR DESCRIPTION
Fix ELF permission, allow the executable permission to all expand to group and owner 

Fix #310