### PR TITLE
CI: mypy: Fix missing stubs for third-party libs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,9 @@ jobs:
         pip install pyfakefs pytest-cov pytest-timeout pylint mypy isort black asyncmock
         find . -type f -name "setup.py" | xargs --max-lines=1 --replace=% python % install --user
 
+        # Install necessary typesheds for mypy tests  
+        pip install types-requests
+
         MAVLINK_ROUTER_PATH="/tmp/mavlink-router"
         sudo apt install autoconf g++ git libtool make pkg-config python3-future
         mkdir ${MAVLINK_ROUTER_PATH}

--- a/core/services/ardupilot_manager/firmware_download/FirmwareDownload.py
+++ b/core/services/ardupilot_manager/firmware_download/FirmwareDownload.py
@@ -300,6 +300,10 @@ class FirmwareDownload:
 
         path = FirmwareDownload._download(url)
 
+        if not path:
+            logger.error("Failed to download firmware.")
+            return None
+
         firmware_format = FirmwareDownload._supported_firmware_formats[platform]
         if firmware_format == FirmwareFormat.ELF:
             # Make the binary executable
@@ -310,7 +314,7 @@ class FirmwareDownload:
             ## For more information: https://www.gnu.org/software/libc/manual/html_node/Permission-Bits.html
             path.chmod(path.stat().st_mode | stat.S_IXOTH | stat.S_IXUSR | stat.S_IXGRP)
 
-        if not path or not FirmwareDownload._validate_firmware(path):
+        if not FirmwareDownload._validate_firmware(path):
             logger.error("Unable to validate firmware file.")
             return None
 


### PR DESCRIPTION
Mypy doesn't install stubs for third-party libraries anymore by default, like explained on the following article:

https://mypy-lang.blogspot.com/2021/05/the-upcoming-switch-to-modular-typeshed.html

Fix #315 