### PR TITLE
core: services: ping: reuse the connection when testing a baudrate

### DIFF
--- a/core/services/ping/pingdriver.py
+++ b/core/services/ping/pingdriver.py
@@ -27,9 +27,9 @@ class PingDriver:
         for baud in Baudrates:
             logging.debug(f"Trying baud {baud}...")
             failures = 0
+            ping = PingDevice()
+            ping.connect_serial(self.ping.port.device, baud)
             for _ in range(attempts):
-                ping = PingDevice()
-                ping.connect_serial(self.ping.port.device, baud)
                 device_info = ping.request(COMMON_DEVICE_INFORMATION)
                 if device_info is None:
                     failures += 1


### PR DESCRIPTION
Re-starting the connection every time makes the process a lot slower.
image coming soon.