### PR TITLE
core: ping: Fix driver

### DIFF
--- a/core/services/ping/pingdriver.py
+++ b/core/services/ping/pingdriver.py
@@ -30,7 +30,7 @@ class PingDriver:
             ping = PingDevice()
             ping.connect_serial(self.ping.port.device, baud)
             for _ in range(attempts):
-                device_info = ping.request(COMMON_DEVICE_INFORMATION)
+                device_info = ping.request(COMMON_DEVICE_INFORMATION, timeout=0.1)
                 if device_info is None:
                     failures += 1
                     if failures > max_failures:


### PR DESCRIPTION
Alternative to #317 

It appears that the true problem is how 4M baudrate works, in the end the sensor can operate with it, but it may fail with high frequency requests. This PR decrease the timeout to allow baud rates that can answer as faster as 100ms.