### PR TITLE
core: Remove commonwealth from services installation

### DIFF
--- a/core/services/install-services.sh
+++ b/core/services/install-services.sh
@@ -16,9 +16,6 @@ RUNTIME_PACKAGES=(
 apt install -y --no-install-recommends ${BUILD_PACKAGES[*]}
 apt install -y --no-install-recommends ${RUNTIME_PACKAGES[*]}
 
-# Commonwealth library:
-cd /home/pi/services/commonwealth/ && python3 setup.py install
-
 # Wifi service:
 ## Bind path for wpa
 mkdir -p /var/run/wpa_supplicant/


### PR DESCRIPTION
This passed by on PR #330.

[Did not interfere with installation itself](https://github.com/bluerobotics/companion-docker/runs/2811096298?check_suite_focus=true#step:7:3364), though.