### PR TITLE
core: versionchooser: cleanup dangling images after a pull

### DIFF
--- a/core/services/versionchooser/utils/chooser.py
+++ b/core/services/versionchooser/utils/chooser.py
@@ -92,6 +92,9 @@ class VersionChooser:
         for line in low_level_api.pull(f"{repository}:{tag}", stream=True, decode=True):
             await response.write(f"{line}\n\n".replace("'", '"').encode("utf-8"))
         await response.write_eof()
+        # Remove any untagged and unused images after pulling
+        # If updating a tag, the previous image will be cleaned up in this step
+        self.client.images.prune(filters={"dangling": True})
         return response
 
     async def set_version(self, image: str, tag: str) -> web.StreamResponse:


### PR DESCRIPTION
image : williangalvani/companion-core:prune
This adds a cleanup step after pulling images. The dangling ones (not used by a container and not tagged) are removed from the disk:

![prune](https://user-images.githubusercontent.com/4013804/122263017-5aeb5100-ceac-11eb-91c0-18737d1908be.gif)
