### PR TITLE
Move tlogs to `.config` folder making them persistent

### DIFF
--- a/core/services/ardupilot_manager/ArduPilotManager.py
+++ b/core/services/ardupilot_manager/ArduPilotManager.py
@@ -26,7 +26,7 @@ class ArduPilotManager(metaclass=Singleton):
             logger.info(f"Loaded settings from {self.settings.settings_file}.")
             logger.debug(self.settings.content)
         else:
-            self.settings.create_settings()
+            self.settings.create_settings_file()
 
         self.configuration = deepcopy(self.settings.content)
         self._load_endpoints()

--- a/core/services/ardupilot_manager/ArduPilotManager.py
+++ b/core/services/ardupilot_manager/ArduPilotManager.py
@@ -20,6 +20,7 @@ class ArduPilotManager(metaclass=Singleton):
     def __init__(self) -> None:
         self.settings = Settings()
         self.mavlink_manager = MavlinkManager()
+        self.mavlink_manager.set_logdir(self.settings.log_path)
 
         # Load settings and do the initial configuration
         if self.settings.load():

--- a/core/services/ardupilot_manager/mavlink_proxy/Manager.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/Manager.py
@@ -1,3 +1,4 @@
+import pathlib
 from typing import List, Set, Type
 
 # Plugins
@@ -73,3 +74,6 @@ class Manager:
 
     def router_name(self) -> str:
         return self.tool.name()
+
+    def set_logdir(self, log_dir: pathlib.Path) -> None:
+        self.tool.set_logdir(log_dir)

--- a/core/services/ardupilot_manager/settings.py
+++ b/core/services/ardupilot_manager/settings.py
@@ -12,7 +12,8 @@ class Settings:
     settings_path = Path(appdirs.user_config_dir(app_name))
     settings_file = Path.joinpath(settings_path, "settings.json")
     firmware_path = Path.joinpath(settings_path, "firmware")
-    app_folders = [settings_path, firmware_path]
+    log_path = Path.joinpath(settings_path, "logs")
+    app_folders = [settings_path, firmware_path, log_path]
 
     def __init__(self) -> None:
         self.root: Dict[str, Union[int, Dict[str, Any]]] = {"version": 0, "content": {}}

--- a/core/services/ardupilot_manager/settings.py
+++ b/core/services/ardupilot_manager/settings.py
@@ -12,15 +12,26 @@ class Settings:
     settings_path = Path(appdirs.user_config_dir(app_name))
     settings_file = Path.joinpath(settings_path, "settings.json")
     firmware_path = Path.joinpath(settings_path, "firmware")
+    app_folders = [settings_path, firmware_path]
 
     def __init__(self) -> None:
         self.root: Dict[str, Union[int, Dict[str, Any]]] = {"version": 0, "content": {}}
+        self.create_app_folders()
 
-    def create_settings(self) -> None:
-        """Create settings files and folders."""
+    @staticmethod
+    def create_app_folders() -> None:
+        """Create the necessary folders for proper app function."""
+        for folder in Settings.app_folders:
+            try:
+                Path.mkdir(folder, exist_ok=True)
+            except FileExistsError:
+                logger.warning(f"Found file {folder} where a folder should be. Removing file and creating folder.")
+                Path.unlink(folder)
+                Path.mkdir(folder)
+
+    def create_settings_file(self) -> None:
+        """Create settings file."""
         try:
-            Path.mkdir(self.settings_path, exist_ok=True)
-            Path.mkdir(self.firmware_path, exist_ok=True)
             if not Path.is_file(self.settings_file):
                 with open(self.settings_file, "w+") as file:
                     logger.info(f"Creating settings file: {self.settings_file}")


### PR DESCRIPTION
This PR fixes #353 by allowing mavlink-manager to set the logs directory and changing it to the `logs` folder, created under the app folder.

To allow for better execution and catching behaviors correctly, I separated the methods to create the folders and to create the settings file. This way we always make sure the app folders are there, independently of having or not a settings file (e.g. there could be the case where the logs folder is not there but the settings file is, thus the logs folder not being created).

This fixes the problem of lost logs for now and makes the path for the future decision of where to better put the files, raised by @Williangalvani on #354.