### PR TITLE
core: mavlink_router: Add apt update before install commands

### DIFF
--- a/core/tools/mavlink_router/bootstrap.py
+++ b/core/tools/mavlink_router/bootstrap.py
@@ -45,6 +45,9 @@ def run_apt_uninstall(package: str) -> None:
 
 
 print("Starting..")
+# Run apt update before starting installing stuff
+run_command("apt update")
+
 run_apt_install("autoconf g++ git libtool make pkg-config")
 run_command("pip install future==0.18.2")
 


### PR DESCRIPTION
As a general rule we should add apt update before calling apt install, this avoid problems related to mirror updates.
I got the same problem every single time in this package because, since we don't know where docker is going to cache, we should do when necessary. 