### PR TITLE
core: services: install-services: Remove python3 installation

### DIFF
--- a/core/services/install-services.sh
+++ b/core/services/install-services.sh
@@ -7,15 +7,8 @@ BUILD_PACKAGES=(
     g++
 )
 
-RUNTIME_PACKAGES=(
-    python3-dev
-    python3-pip
-    python3-setuptools
-)
-
 apt update
 apt install -y --no-install-recommends ${BUILD_PACKAGES[*]}
-apt install -y --no-install-recommends ${RUNTIME_PACKAGES[*]}
 
 # Wifi service:
 ## Bind path for wpa


### PR DESCRIPTION
We already have python 3.9 available.

This also removes 80MB from our image. 