### PR TITLE
eslint: Use Vue2 rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,7 +7,7 @@ module.exports = {
   },
   extends: [
     'eslint:recommended',
-    'plugin:vue/vue3-strongly-recommended',
+    'plugin:vue/strongly-recommended',
     '@vue/typescript/recommended',
   ],
   parserOptions: {


### PR DESCRIPTION
We are currently using Vue2 on the repo, instead of Vue3.

We thought before Vue3 rules was a superset of Vue2 rules, and they seem to be, but using Vue3 rules raise some warnings regarding new features introduced by Vue3, like [the emits declaration](https://v3.vuejs.org/guide/migration/emits-option.html#_3-x-behavior), that we don't have available (there are more, for sure, but this was the one I've faced already).