### PR TITLE
core: libs: commonwealth: Fix calling setup.py from different path

### DIFF
--- a/core/libs/commonwealth/setup.py
+++ b/core/libs/commonwealth/setup.py
@@ -1,6 +1,11 @@
+import os
 import pathlib
 
 import setuptools
+
+# Force current path to be used as reference for Python
+## Fix problems related to calling setup.py from different paths
+os.chdir(os.path.abspath(os.path.dirname(__file__)))
 
 with open(pathlib.Path(__file__).parent.joinpath("README.md"), "r") as readme:
     long_description = readme.read()


### PR DESCRIPTION
Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>

docker: patrickelectric/companion-core:fix-common