### PR TITLE
use wheel for aiohttp in armv7

### DIFF
--- a/core/services/install-services.sh
+++ b/core/services/install-services.sh
@@ -10,6 +10,13 @@ BUILD_PACKAGES=(
 apt update
 apt install -y --no-install-recommends ${BUILD_PACKAGES[*]}
 
+# Pre-Build dependencies:
+# For convenience, we build ourselves the .wheel packages for dependencies
+# which have no armv7 wheel in pypi. This saves a lot of build time in docker
+if [[ "$(uname -m)" == "armv7l"* ]]; then
+    pip install https://s3.amazonaws.com/downloads.bluerobotics.com/companion-docker/wheels/aiohttp-3.7.4-cp39-cp39-linux_armv7l.whl
+fi
+
 # Wifi service:
 ## Bind path for wpa
 mkdir -p /var/run/wpa_supplicant/

--- a/core/services/versionchooser/setup.py
+++ b/core/services/versionchooser/setup.py
@@ -40,7 +40,7 @@ setup(
     license="MIT",
     install_requires=[
         "aiohttp-jinja2 == 1.4.2",
-        "aiohttp == 3.7.3",
+        "aiohttp == 3.7.4",
         "connexion[swagger-ui, aiohttp] == 2.7.0",
         "docker == 4.4.4",
         "appdirs == 1.4.4",


### PR DESCRIPTION
This should speed up arm builds.
This also uses PIP to install the services as vannila setup-tools is unable to handle [PEP 508](https://www.python.org/dev/peps/pep-0508/)