### PR TITLE
Refactor wifi service

### DIFF
--- a/core/services/wifi/WifiManager.py
+++ b/core/services/wifi/WifiManager.py
@@ -138,7 +138,10 @@ class WifiManager:
             network_number = await self.wpa.send_command_add_network()
 
             await self.wpa.send_command_set_network(network_number, "ssid", f'"{credentials.ssid}"')
-            await self.wpa.send_command_set_network(network_number, "psk", f'"{credentials.password}"')
+            if not credentials.password:
+                await self.wpa.send_command_set_network(network_number, "key_mgmt", "NONE")
+            else:
+                await self.wpa.send_command_set_network(network_number, "psk", f'"{credentials.password}"')
             await self.wpa.send_command_save_config()
             await self.wpa.send_command_reconfigure()
             return network_number

--- a/core/services/wifi/WifiManager.py
+++ b/core/services/wifi/WifiManager.py
@@ -135,14 +135,13 @@ class WifiManager:
             credentials {[WifiCredentials]} -- object containing ssid and password of the network
         """
         try:
-            data = await self.wpa.send_command_add_network()
+            network_number = await self.wpa.send_command_add_network()
 
-            network_number = data.decode("utf-8")
             await self.wpa.send_command_set_network(network_number, "ssid", f'"{credentials.ssid}"')
             await self.wpa.send_command_set_network(network_number, "psk", f'"{credentials.password}"')
             await self.wpa.send_command_save_config()
             await self.wpa.send_command_reconfigure()
-            return int(network_number)
+            return network_number
         except Exception as error:
             raise ConnectionError("Failed to set new network.") from error
 
@@ -153,7 +152,7 @@ class WifiManager:
             network_id {int} -- Network ID provided by WPA Supplicant
         """
         try:
-            await self.wpa.send_command_enable_network(str(network_id))
+            await self.wpa.send_command_enable_network(network_id)
             await self.wpa.send_command_save_config()
             await self.wpa.send_command_reconfigure()
             await self.wpa.send_command_reconnect()

--- a/core/services/wifi/WifiManager.py
+++ b/core/services/wifi/WifiManager.py
@@ -165,7 +165,12 @@ class WifiManager:
             network_id {int} -- Network ID provided by WPA Supplicant
         """
         try:
-            await self.wpa.send_command_enable_network(network_id)
+            # Using select_network forces connection on the desired network by disabling all the others. To ensure we
+            # can still automatically connect to the other saved networks when far from this one, we re-enable them.
+            await self.wpa.send_command_select_network(network_id)
+            saved_networks = await self.get_saved_wifi_network()
+            for network in saved_networks:
+                await self.wpa.send_command_enable_network(network.networkid)
             await self.wpa.send_command_save_config()
             await self.wpa.send_command_reconfigure()
             await self.wpa.send_command_reconnect()

--- a/core/services/wifi/WifiManager.py
+++ b/core/services/wifi/WifiManager.py
@@ -84,7 +84,7 @@ class WifiManager:
     async def get_wifi_available(self) -> List[ScannedWifiNetwork]:
         """Get a dict from the wifi signals available"""
         try:
-            await self.wpa.send_command_scan()
+            await self.wpa.send_command_scan(timeout=15)
             data = await self.wpa.send_command_scan_results()
             networks_list = WifiManager.__dict_from_table(data)
             return [ScannedWifiNetwork(**network) for network in networks_list]

--- a/core/services/wifi/WifiManager.py
+++ b/core/services/wifi/WifiManager.py
@@ -2,19 +2,8 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel
 
+from exceptions import BusyError, FetchError, ParseError
 from wpa_supplicant import WPASupplicant
-
-
-class ParseError(ValueError):
-    """Raise for errors regarding fail parsing string data to proper structs."""
-
-
-class FetchError(ValueError):
-    """Raise for errors regarding fail on fetching data."""
-
-
-class BusyError(ValueError):
-    """Raise for errors regarding excessive number of requests on a given time."""
 
 
 class ScannedWifiNetwork(BaseModel):

--- a/core/services/wifi/WifiManager.py
+++ b/core/services/wifi/WifiManager.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List
 
-from exceptions import BusyError, FetchError, ParseError
+from exceptions import FetchError, ParseError
 from typedefs import SavedWifiNetwork, ScannedWifiNetwork, WifiCredentials
 from wpa_supplicant import WPASupplicant
 
@@ -84,14 +84,10 @@ class WifiManager:
     def get_wifi_available(self) -> List[ScannedWifiNetwork]:
         """Get a dict from the wifi signals available"""
         try:
-            scan_data = self.wpa.send_command_scan()
-            if b"BUSY" in scan_data:
-                raise BusyError
+            self.wpa.send_command_scan()
             data = self.wpa.send_command_scan_results()
             networks_list = WifiManager.__dict_from_table(data)
             return [ScannedWifiNetwork(**network) for network in networks_list]
-        except BusyError as error:
-            raise BusyError("WPA service is busy. Try to space network scans by at least 4 seconds.") from error
         except Exception as error:
             raise FetchError("Failed to fetch wifi list.") from error
 

--- a/core/services/wifi/WifiManager.py
+++ b/core/services/wifi/WifiManager.py
@@ -108,9 +108,6 @@ class WifiManager:
         """
         try:
             data = await self.wpa.send_command_add_network()
-            data = data.strip()
-            if data == b"Fail":
-                raise RuntimeError("Failed to add new network.")
 
             network_number = data.decode("utf-8")
             await self.wpa.send_command_set_network(network_number, "ssid", '"{}"'.format(credentials.ssid))
@@ -118,11 +115,7 @@ class WifiManager:
             await self.wpa.send_command_enable_network(network_number)
             await self.wpa.send_command_reconnect()
 
-            answer = await self.wpa.send_command_save_config()
-            answer = answer.strip()
-            if answer == b"FAIL":
-                raise RuntimeError(str(answer))
-
+            await self.wpa.send_command_save_config()
             await self.wpa.send_command_reconfigure()
         except Exception as error:
             raise ConnectionError("Failed to set new network.") from error

--- a/core/services/wifi/WifiManager.py
+++ b/core/services/wifi/WifiManager.py
@@ -81,74 +81,74 @@ class WifiManager:
 
         return output
 
-    def get_wifi_available(self) -> List[ScannedWifiNetwork]:
+    async def get_wifi_available(self) -> List[ScannedWifiNetwork]:
         """Get a dict from the wifi signals available"""
         try:
-            self.wpa.send_command_scan()
-            data = self.wpa.send_command_scan_results()
+            await self.wpa.send_command_scan()
+            data = await self.wpa.send_command_scan_results()
             networks_list = WifiManager.__dict_from_table(data)
             return [ScannedWifiNetwork(**network) for network in networks_list]
         except Exception as error:
             raise FetchError("Failed to fetch wifi list.") from error
 
-    def get_saved_wifi_network(self) -> List[SavedWifiNetwork]:
+    async def get_saved_wifi_network(self) -> List[SavedWifiNetwork]:
         """Get a list of saved wifi networks"""
         try:
-            data = self.wpa.send_command_list_networks()
+            data = await self.wpa.send_command_list_networks()
             networks_list = WifiManager.__dict_from_table(data)
             return [SavedWifiNetwork(**network) for network in networks_list]
         except Exception as error:
             raise FetchError("Failed to fetch saved networks list.") from error
 
-    def set_wifi_password(self, credentials: WifiCredentials) -> Any:
+    async def set_wifi_password(self, credentials: WifiCredentials) -> Any:
         """Set network ssid and password
 
         Arguments:
             credentials {[WifiCredentials]} -- object containing ssid and password of the network
         """
         try:
-            data = self.wpa.send_command_add_network()
+            data = await self.wpa.send_command_add_network()
             data = data.strip()
             if data == b"Fail":
                 raise RuntimeError("Failed to add new network.")
 
             network_number = data.decode("utf-8")
-            self.wpa.send_command_set_network(network_number, "ssid", '"{}"'.format(credentials.ssid))
-            self.wpa.send_command_set_network(network_number, "psk", '"{}"'.format(credentials.password))
-            self.wpa.send_command_enable_network(network_number)
-            self.wpa.send_command_reconnect()
+            await self.wpa.send_command_set_network(network_number, "ssid", '"{}"'.format(credentials.ssid))
+            await self.wpa.send_command_set_network(network_number, "psk", '"{}"'.format(credentials.password))
+            await self.wpa.send_command_enable_network(network_number)
+            await self.wpa.send_command_reconnect()
 
-            answer = self.wpa.send_command_save_config()
+            answer = await self.wpa.send_command_save_config()
             answer = answer.strip()
             if answer == b"FAIL":
                 raise RuntimeError(str(answer))
 
-            self.wpa.send_command_reconfigure()
+            await self.wpa.send_command_reconfigure()
         except Exception as error:
             raise ConnectionError("Failed to set new network.") from error
 
-    def status(self) -> Dict[str, Any]:
+    async def status(self) -> Dict[str, Any]:
         """Check wpa_supplicant status"""
         try:
-            data = self.wpa.send_command_status()
+            data = await self.wpa.send_command_status()
             return WifiManager.__dict_from_list(data)
         except Exception as error:
             raise FetchError("Failed to get status from wifi manager.") from error
 
-    def reconfigure(self) -> None:
+    async def reconfigure(self) -> None:
         """Reconfigure wpa_supplicant
         This will force the reevaluation of the conf file
         """
         try:
-            self.wpa.send_command_reconfigure()
+            await self.wpa.send_command_reconfigure()
         except Exception as error:
             raise RuntimeError("Failed to reconfigure wifi manager.") from error
 
-    def disconnect(self) -> None:
+    async def disconnect(self) -> None:
         """Reconfigure wpa_supplicant
         This will force the reevaluation of the conf file
         """
         try:
-            self.wpa.send_command_disconnect()
+            await self.wpa.send_command_disconnect()
         except Exception as error:
             raise ConnectionError("Failed to disconnect from wifi network.") from error

--- a/core/services/wifi/WifiManager.py
+++ b/core/services/wifi/WifiManager.py
@@ -138,9 +138,8 @@ class WifiManager:
             data = await self.wpa.send_command_add_network()
 
             network_number = data.decode("utf-8")
-            await self.wpa.send_command_set_network(network_number, "ssid", '"{}"'.format(credentials.ssid))
-            await self.wpa.send_command_set_network(network_number, "psk", '"{}"'.format(credentials.password))
-
+            await self.wpa.send_command_set_network(network_number, "ssid", f'"{credentials.ssid}"')
+            await self.wpa.send_command_set_network(network_number, "psk", f'"{credentials.password}"')
             await self.wpa.send_command_save_config()
             await self.wpa.send_command_reconfigure()
             return int(network_number)

--- a/core/services/wifi/WifiManager.py
+++ b/core/services/wifi/WifiManager.py
@@ -1,29 +1,8 @@
-from typing import Any, Dict, List, Optional
-
-from pydantic import BaseModel
+from typing import Any, Dict, List
 
 from exceptions import BusyError, FetchError, ParseError
+from typedefs import SavedWifiNetwork, ScannedWifiNetwork, WifiCredentials
 from wpa_supplicant import WPASupplicant
-
-
-class ScannedWifiNetwork(BaseModel):
-    ssid: Optional[str]
-    bssid: str
-    flags: str
-    frequency: int
-    signallevel: int
-
-
-class SavedWifiNetwork(BaseModel):
-    networkid: int
-    ssid: str
-    bssid: str
-    flags: Optional[str]
-
-
-class WifiCredentials(BaseModel):
-    ssid: str
-    password: str
 
 
 class WifiManager:

--- a/core/services/wifi/WifiManager.py
+++ b/core/services/wifi/WifiManager.py
@@ -145,6 +145,19 @@ class WifiManager:
         except Exception as error:
             raise ConnectionError("Failed to set new network.") from error
 
+    async def remove_network(self, network_id: int) -> None:
+        """Remove saved wifi network
+
+        Arguments:
+            network_id {int} -- Network ID as it comes from WPA Supplicant list of saved networks
+        """
+        try:
+            await self.wpa.send_command_remove_network(network_id)
+            await self.wpa.send_command_save_config()
+            await self.wpa.send_command_reconfigure()
+        except Exception as error:
+            raise ConnectionError("Failed to remove existing network.") from error
+
     async def connect_to_network(self, network_id: int) -> None:
         """Connect to wifi network
 

--- a/core/services/wifi/WifiManager.py
+++ b/core/services/wifi/WifiManager.py
@@ -128,11 +128,13 @@ class WifiManager:
         except Exception as error:
             raise FetchError("Failed to fetch saved networks list.") from error
 
-    async def add_network(self, credentials: WifiCredentials) -> int:
+    async def add_network(self, credentials: WifiCredentials, hidden: bool = False) -> int:
         """Set network ssid and password
 
         Arguments:
             credentials {[WifiCredentials]} -- object containing ssid and password of the network
+            hidden {bool} -- Should be set as true when adding hidden networks (networks that do not broadcast
+            the SSID, or on other words, that have SSID as blank or null on the scan results). False by default.
         """
         try:
             network_number = await self.wpa.send_command_add_network()
@@ -142,6 +144,8 @@ class WifiManager:
                 await self.wpa.send_command_set_network(network_number, "key_mgmt", "NONE")
             else:
                 await self.wpa.send_command_set_network(network_number, "psk", f'"{credentials.password}"')
+            if hidden:
+                await self.wpa.send_command_set_network(network_number, "scan_ssid", "1")
             await self.wpa.send_command_save_config()
             await self.wpa.send_command_reconfigure()
             return network_number

--- a/core/services/wifi/WifiManager.py
+++ b/core/services/wifi/WifiManager.py
@@ -15,8 +15,6 @@ class WifiManager:
             path {[tuple/str]} -- Can be a tuple to connect (ip/port) or unix socket file
         """
         self.wpa.run(path)
-        # Request scan to update state
-        self.wpa.send_command_scan()
 
     @staticmethod
     def __decode_escaped(data: bytes) -> str:

--- a/core/services/wifi/exceptions.py
+++ b/core/services/wifi/exceptions.py
@@ -21,3 +21,7 @@ class SockCommError(ConnectionError):
 
 class WPAOperationFail(ConnectionError):
     """Raised when a WPA operation fails."""
+
+
+class NetworkAddFail(ValueError):
+    """Raised when a WPA add_network operation fails to return an int."""

--- a/core/services/wifi/exceptions.py
+++ b/core/services/wifi/exceptions.py
@@ -13,3 +13,7 @@ class FetchError(ValueError):
 
 class BusyError(ValueError):
     """Raise for errors regarding excessive number of requests on a given time."""
+
+
+class SockCommError(ConnectionError):
+    """Raise for errors regarding WPA socket communication."""

--- a/core/services/wifi/exceptions.py
+++ b/core/services/wifi/exceptions.py
@@ -17,3 +17,7 @@ class BusyError(ValueError):
 
 class SockCommError(ConnectionError):
     """Raise for errors regarding WPA socket communication."""
+
+
+class WPAOperationFail(ConnectionError):
+    """Raised when a WPA operation fails."""

--- a/core/services/wifi/exceptions.py
+++ b/core/services/wifi/exceptions.py
@@ -1,0 +1,15 @@
+"""
+Wifi-manager exception classes.
+"""
+
+
+class ParseError(ValueError):
+    """Raise for errors regarding fail parsing string data to proper structs."""
+
+
+class FetchError(ValueError):
+    """Raise for errors regarding fail on fetching data."""
+
+
+class BusyError(ValueError):
+    """Raise for errors regarding excessive number of requests on a given time."""

--- a/core/services/wifi/main.py
+++ b/core/services/wifi/main.py
@@ -62,7 +62,14 @@ async def saved() -> Any:
 @version(1, 0)
 async def connect(credentials: WifiCredentials) -> Any:
     try:
-        await wifi_manager.set_wifi_password(credentials)
+        saved_networks = await wifi_manager.get_saved_wifi_network()
+        match_network = next(filter(lambda network: network.ssid == credentials.ssid, saved_networks))
+        network_id = match_network.networkid
+    except StopIteration:
+        network_id = await wifi_manager.add_network(credentials)
+
+    try:
+        await wifi_manager.connect_to_network(network_id)
     except ConnectionError as error:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(error)) from error
 

--- a/core/services/wifi/main.py
+++ b/core/services/wifi/main.py
@@ -12,9 +12,8 @@ from fastapi import FastAPI, HTTPException, status
 from fastapi.staticfiles import StaticFiles
 from fastapi_versioning import VersionedFastAPI, version
 
+from exceptions import BusyError, FetchError
 from WifiManager import (
-    BusyError,
-    FetchError,
     SavedWifiNetwork,
     ScannedWifiNetwork,
     WifiCredentials,

--- a/core/services/wifi/main.py
+++ b/core/services/wifi/main.py
@@ -13,12 +13,8 @@ from fastapi.staticfiles import StaticFiles
 from fastapi_versioning import VersionedFastAPI, version
 
 from exceptions import BusyError, FetchError
-from WifiManager import (
-    SavedWifiNetwork,
-    ScannedWifiNetwork,
-    WifiCredentials,
-    WifiManager,
-)
+from typedefs import SavedWifiNetwork, ScannedWifiNetwork, WifiCredentials
+from WifiManager import WifiManager
 
 FRONTEND_FOLDER = Path.joinpath(Path(__file__).parent.absolute(), "frontend")
 

--- a/core/services/wifi/main.py
+++ b/core/services/wifi/main.py
@@ -31,18 +31,18 @@ app = FastAPI(
 
 @app.get("/status", summary="Retrieve status of wifi manager.")
 @version(1, 0)
-def network_status() -> Any:
+async def network_status() -> Any:
     try:
-        return wifi_manager.status()
+        return await wifi_manager.status()
     except FetchError as error:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(error)) from error
 
 
 @app.get("/scan", response_model=List[ScannedWifiNetwork], summary="Retrieve available wifi networks.")
 @version(1, 0)
-def scan() -> Any:
+async def scan() -> Any:
     try:
-        return wifi_manager.get_wifi_available()
+        return await wifi_manager.get_wifi_available()
     except BusyError as error:
         raise HTTPException(status_code=status.HTTP_425_TOO_EARLY, detail=str(error)) from error
     except FetchError as error:
@@ -51,27 +51,27 @@ def scan() -> Any:
 
 @app.get("/saved", response_model=List[SavedWifiNetwork], summary="Retrieve saved wifi networks.")
 @version(1, 0)
-def saved() -> Any:
+async def saved() -> Any:
     try:
-        return wifi_manager.get_saved_wifi_network()
+        return await wifi_manager.get_saved_wifi_network()
     except FetchError as error:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(error)) from error
 
 
 @app.post("/connect", summary="Connect to wifi network.")
 @version(1, 0)
-def connect(credentials: WifiCredentials) -> Any:
+async def connect(credentials: WifiCredentials) -> Any:
     try:
-        wifi_manager.set_wifi_password(credentials)
+        await wifi_manager.set_wifi_password(credentials)
     except ConnectionError as error:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(error)) from error
 
 
 @app.get("/disconnect", summary="Disconnect from wifi network.")
 @version(1, 0)
-def disconnect() -> Any:
+async def disconnect() -> Any:
     try:
-        wifi_manager.disconnect()
+        await wifi_manager.disconnect()
     except ConnectionError as error:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(error)) from error
 

--- a/core/services/wifi/main.py
+++ b/core/services/wifi/main.py
@@ -69,13 +69,13 @@ async def saved() -> Any:
 
 @app.post("/connect", summary="Connect to wifi network.")
 @version(1, 0)
-async def connect(credentials: WifiCredentials) -> Any:
+async def connect(credentials: WifiCredentials, hidden: bool = False) -> Any:
     try:
         saved_networks = await wifi_manager.get_saved_wifi_network()
         match_network = next(filter(lambda network: network.ssid == credentials.ssid, saved_networks))
         network_id = match_network.networkid
     except StopIteration:
-        network_id = await wifi_manager.add_network(credentials)
+        network_id = await wifi_manager.add_network(credentials, hidden)
 
     try:
         await wifi_manager.connect_to_network(network_id)

--- a/core/services/wifi/main.py
+++ b/core/services/wifi/main.py
@@ -84,6 +84,20 @@ async def connect(credentials: WifiCredentials) -> Any:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(error)) from error
 
 
+@app.post("/remove", summary="Remove saved wifi network.")
+@version(1, 0)
+async def remove(ssid: str) -> Any:
+    try:
+        saved_networks = await wifi_manager.get_saved_wifi_network()
+        match_network = next(filter(lambda network: network.ssid == ssid, saved_networks))
+        await wifi_manager.remove_network(match_network.networkid)
+    except StopIteration as error:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Network '{ssid}' not saved.") from error
+    except ConnectionError as error:
+        logger.exception(error)
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(error)) from error
+
+
 @app.get("/disconnect", summary="Disconnect from wifi network.")
 @version(1, 0)
 async def disconnect() -> Any:

--- a/core/services/wifi/typedefs.py
+++ b/core/services/wifi/typedefs.py
@@ -1,0 +1,23 @@
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class ScannedWifiNetwork(BaseModel):
+    ssid: Optional[str]
+    bssid: str
+    flags: str
+    frequency: int
+    signallevel: int
+
+
+class SavedWifiNetwork(BaseModel):
+    networkid: int
+    ssid: str
+    bssid: str
+    flags: Optional[str]
+
+
+class WifiCredentials(BaseModel):
+    ssid: str
+    password: str

--- a/core/services/wifi/wpa_supplicant.py
+++ b/core/services/wifi/wpa_supplicant.py
@@ -1,3 +1,4 @@
+import asyncio
 import glob
 import os
 import socket
@@ -49,7 +50,7 @@ class WPASupplicant:
         self.sock.settimeout(10)
         self.sock.connect(self.target)
 
-    def send_command(self, command: str, timeout: float) -> bytes:
+    async def send_command(self, command: str, timeout: float) -> bytes:
         """Send a specific WPA Supplicant command.
         Raises if the command fails to answer before the specified timeout.
 
@@ -67,7 +68,7 @@ class WPASupplicant:
                 data, _ = self.sock.recvfrom(self.BUFFER_SIZE)
                 if b"FAIL-BUSY" in data:
                     print(f"Busy during {command} operation. Trying again...")
-                    time.sleep(0.1)
+                    await asyncio.sleep(0.1)
                     continue
                 break
             else:
@@ -78,7 +79,7 @@ class WPASupplicant:
             raise SockCommError("Could not communicate with WPA Supplicant socket.") from error
         return data
 
-    def send_command_ping(self, timeout: float = 1) -> bytes:
+    async def send_command_ping(self, timeout: float = 1) -> bytes:
         """Send message: PING
 
         This command can be used to test whether wpa_supplicant is replying to
@@ -86,161 +87,161 @@ class WPASupplicant:
             if the connection is open and wpa_supplicant is processing commands.
 
         """
-        return self.send_command("PING", timeout)
+        return await self.send_command("PING", timeout)
 
-    def send_command_mib(self, timeout: float = 1) -> bytes:
+    async def send_command_mib(self, timeout: float = 1) -> bytes:
         """Send message: MIB
 
         Request a list of MIB variables (dot1x, dot11). The output is a text block
             with each line in  <code>variable=value</code>  format. For example:
 
         """
-        return self.send_command("MIB", timeout)
+        return await self.send_command("MIB", timeout)
 
-    def send_command_status(self, timeout: float = 1) -> bytes:
+    async def send_command_status(self, timeout: float = 1) -> bytes:
         """Send message: STATUS
 
         Request current WPA/EAPOL/EAP status information. The output is a text
             block with each line in  <code>variable=value</code>  format. For
             example:
         """
-        return self.send_command("STATUS", timeout)
+        return await self.send_command("STATUS", timeout)
 
-    def send_command_status_verbose(self, timeout: float = 1) -> bytes:
+    async def send_command_status_verbose(self, timeout: float = 1) -> bytes:
         """Send message: STATUS-VERBOSE
 
         Same as STATUS, but with more verbosity (i.e., more  <code>variable=value</code>
             pairs).
         """
-        return self.send_command("STATUS-VERBOSE", timeout)
+        return await self.send_command("STATUS-VERBOSE", timeout)
 
-    def send_command_pmksa(self, timeout: float = 1) -> bytes:
+    async def send_command_pmksa(self, timeout: float = 1) -> bytes:
         """Send message: PMKSA
 
         Show PMKSA cache
         """
-        return self.send_command("PMKSA", timeout)
+        return await self.send_command("PMKSA", timeout)
 
-    def send_command_set(self, variable: str, value: str, timeout: float = 1) -> bytes:
+    async def send_command_set(self, variable: str, value: str, timeout: float = 1) -> bytes:
         """Send message: SET
 
         Example command:
         """
-        return self.send_command("SET" + " " + " ".join([variable, value]), timeout)
+        return await self.send_command("SET" + " " + " ".join([variable, value]), timeout)
 
-    def send_command_logon(self, timeout: float = 1) -> bytes:
+    async def send_command_logon(self, timeout: float = 1) -> bytes:
         """Send message: LOGON
 
         IEEE 802.1X EAPOL state machine logon.
         """
-        return self.send_command("LOGON", timeout)
+        return await self.send_command("LOGON", timeout)
 
-    def send_command_logoff(self, timeout: float = 1) -> bytes:
+    async def send_command_logoff(self, timeout: float = 1) -> bytes:
         """Send message: LOGOFF
 
         IEEE 802.1X EAPOL state machine logoff.
         """
-        return self.send_command("LOGOFF", timeout)
+        return await self.send_command("LOGOFF", timeout)
 
-    def send_command_reassociate(self, timeout: float = 1) -> bytes:
+    async def send_command_reassociate(self, timeout: float = 1) -> bytes:
         """Send message: REASSOCIATE
 
         Force reassociation.
         """
-        return self.send_command("REASSOCIATE", timeout)
+        return await self.send_command("REASSOCIATE", timeout)
 
-    def send_command_reconnect(self, timeout: float = 1) -> bytes:
+    async def send_command_reconnect(self, timeout: float = 1) -> bytes:
         """Send message: RECONNECT
 
         Connect if disconnected (i.e., like  <code>REASSOCIATE</code> , but only
             connect if in disconnected state).
         """
-        return self.send_command("RECONNECT", timeout)
+        return await self.send_command("RECONNECT", timeout)
 
-    def send_command_preauth(self, BSSID: str, timeout: float = 1) -> bytes:
+    async def send_command_preauth(self, BSSID: str, timeout: float = 1) -> bytes:
         """Send message: PREAUTH
 
         Start pre-authentication with the given BSSID.
         """
-        return self.send_command("PREAUTH" + " " + " ".join([BSSID]), timeout)
+        return await self.send_command("PREAUTH" + " " + " ".join([BSSID]), timeout)
 
-    def send_command_attach(self, timeout: float = 1) -> bytes:
+    async def send_command_attach(self, timeout: float = 1) -> bytes:
         """Send message: ATTACH
 
         Attach the connection as a monitor for unsolicited events. This can be
             done with  <a class="el" href="wpa__ctrl_8c.html#a3257febde163010311f3306ac0468257">wpa_ctrl_attach()</a>
             .
         """
-        return self.send_command("ATTACH", timeout)
+        return await self.send_command("ATTACH", timeout)
 
-    def send_command_detach(self, timeout: float = 1) -> bytes:
+    async def send_command_detach(self, timeout: float = 1) -> bytes:
         """Send message: DETACH
 
         Detach the connection as a monitor for unsolicited events. This can be
             done with  <a class="el" href="wpa__ctrl_8c.html#ae326ca921d06153e4efce717ae5dd4da">wpa_ctrl_detach()</a>
             .
         """
-        return self.send_command("DETACH", timeout)
+        return await self.send_command("DETACH", timeout)
 
-    def send_command_level(self, debug_level: str, timeout: float = 1) -> bytes:
+    async def send_command_level(self, debug_level: str, timeout: float = 1) -> bytes:
         """Send message: LEVEL
 
         Change debug level.
         """
-        return self.send_command("LEVEL" + " " + " ".join([debug_level]), timeout)
+        return await self.send_command("LEVEL" + " " + " ".join([debug_level]), timeout)
 
-    def send_command_reconfigure(self, timeout: float = 1) -> bytes:
+    async def send_command_reconfigure(self, timeout: float = 1) -> bytes:
         """Send message: RECONFIGURE
 
         Force wpa_supplicant to re-read its configuration data.
         """
-        return self.send_command("RECONFIGURE", timeout)
+        return await self.send_command("RECONFIGURE", timeout)
 
-    def send_command_terminate(self, timeout: float = 1) -> bytes:
+    async def send_command_terminate(self, timeout: float = 1) -> bytes:
         """Send message: TERMINATE
 
         Terminate wpa_supplicant process.
         """
-        return self.send_command("TERMINATE", timeout)
+        return await self.send_command("TERMINATE", timeout)
 
-    def send_command_bssid(self, network_id: str, BSSID: str, timeout: float = 1) -> bytes:
+    async def send_command_bssid(self, network_id: str, BSSID: str, timeout: float = 1) -> bytes:
         """Send message: BSSID
 
         Set preferred BSSID for a network. Network id can be received from the
             <code>LIST_NETWORKS</code>  command output.
         """
-        return self.send_command("BSSID" + " " + " ".join([network_id, BSSID]), timeout)
+        return await self.send_command("BSSID" + " " + " ".join([network_id, BSSID]), timeout)
 
-    def send_command_list_networks(self, timeout: float = 1) -> bytes:
+    async def send_command_list_networks(self, timeout: float = 1) -> bytes:
         """Send message: LIST_NETWORKS
 
         (note: fields are separated with tabs)
         """
-        return self.send_command("LIST_NETWORKS", timeout)
+        return await self.send_command("LIST_NETWORKS", timeout)
 
-    def send_command_disconnect(self, timeout: float = 1) -> bytes:
+    async def send_command_disconnect(self, timeout: float = 1) -> bytes:
         """Send message: DISCONNECT
 
         Disconnect and wait for  <code>REASSOCIATE</code>  or  <code>RECONNECT</code>
             command before connecting.
         """
-        return self.send_command("DISCONNECT", timeout)
+        return await self.send_command("DISCONNECT", timeout)
 
-    def send_command_scan(self, timeout: float = 1) -> bytes:
+    async def send_command_scan(self, timeout: float = 1) -> bytes:
         """Send message: SCAN
 
         Request a new BSS scan.
         """
-        return self.send_command("SCAN", timeout)
+        return await self.send_command("SCAN", timeout)
 
-    def send_command_scan_results(self, timeout: float = 1) -> bytes:
+    async def send_command_scan_results(self, timeout: float = 1) -> bytes:
         """Send message: SCAN_RESULTS
 
         (note: fields are separated with tabs)
         """
-        return self.send_command("SCAN_RESULTS", timeout)
+        return await self.send_command("SCAN_RESULTS", timeout)
 
-    def send_command_bss(self, timeout: float = 1) -> bytes:
+    async def send_command_bss(self, timeout: float = 1) -> bytes:
         """Send message: BSS
 
         BSS information is presented in following format. Please note that new
@@ -248,35 +249,35 @@ class WPASupplicant:
             user should be prepared to ignore values it does not understand.
 
         """
-        return self.send_command("BSS", timeout)
+        return await self.send_command("BSS", timeout)
 
-    def send_command_select_network(self, network_id: str, timeout: float = 1) -> bytes:
+    async def send_command_select_network(self, network_id: str, timeout: float = 1) -> bytes:
         """Send message: SELECT_NETWORK
 
         Select a network (disable others). Network id can be received from the
             <code>LIST_NETWORKS</code>  command output.
         """
-        return self.send_command("SELECT_NETWORK" + " " + " ".join([network_id]), timeout)
+        return await self.send_command("SELECT_NETWORK" + " " + " ".join([network_id]), timeout)
 
-    def send_command_enable_network(self, network_id: str, timeout: float = 1) -> bytes:
+    async def send_command_enable_network(self, network_id: str, timeout: float = 1) -> bytes:
         """Send message: ENABLE_NETWORK
 
         Enable a network. Network id can be received from the  <code>LIST_NETWORKS</code>
             command output. Special network id  <code>all</code>  can be used
             to enable all network.
         """
-        return self.send_command("ENABLE_NETWORK" + " " + " ".join([network_id]), timeout)
+        return await self.send_command("ENABLE_NETWORK" + " " + " ".join([network_id]), timeout)
 
-    def send_command_disable_network(self, network_id: str, timeout: float = 1) -> bytes:
+    async def send_command_disable_network(self, network_id: str, timeout: float = 1) -> bytes:
         """Send message: DISABLE_NETWORK
 
         Disable a network. Network id can be received from the  <code>LIST_NETWORKS</code>
             command output. Special network id  <code>all</code>  can be used
             to disable all network.
         """
-        return self.send_command("DISABLE_NETWORK" + " " + " ".join([network_id]), timeout)
+        return await self.send_command("DISABLE_NETWORK" + " " + " ".join([network_id]), timeout)
 
-    def send_command_add_network(self, timeout: float = 1) -> bytes:
+    async def send_command_add_network(self, timeout: float = 1) -> bytes:
         """Send message: ADD_NETWORK
 
         Add a new network. This command creates a new network with empty configuration.
@@ -285,41 +286,41 @@ class WPASupplicant:
             returns the network id of the new network or FAIL on failure.
 
         """
-        return self.send_command("ADD_NETWORK", timeout)
+        return await self.send_command("ADD_NETWORK", timeout)
 
-    def send_command_remove_network(self, network_id: str, timeout: float = 1) -> bytes:
+    async def send_command_remove_network(self, network_id: str, timeout: float = 1) -> bytes:
         """Send message: REMOVE_NETWORK
 
         Remove a network. Network id can be received from the  <code>LIST_NETWORKS</code>
             command output. Special network id  <code>all</code>  can be used
             to remove all network.
         """
-        return self.send_command("REMOVE_NETWORK" + " " + " ".join([network_id]), timeout)
+        return await self.send_command("REMOVE_NETWORK" + " " + " ".join([network_id]), timeout)
 
-    def send_command_set_network(self, network_id: str, variable: str, value: str, timeout: float = 1) -> bytes:
+    async def send_command_set_network(self, network_id: str, variable: str, value: str, timeout: float = 1) -> bytes:
         """Send message: SET_NETWORK
 
         This command uses the same variables and data formats as the configuration
             file. See example wpa_supplicant.conf for more details.
         """
-        return self.send_command("SET_NETWORK" + " " + " ".join([network_id, variable, value]), timeout)
+        return await self.send_command("SET_NETWORK" + " " + " ".join([network_id, variable, value]), timeout)
 
-    def send_command_get_network(self, network_id: str, variable: str, timeout: float = 1) -> bytes:
+    async def send_command_get_network(self, network_id: str, variable: str, timeout: float = 1) -> bytes:
         """Send message: GET_NETWORK
 
         Get network variables. Network id can be received from the  <code>LIST_NETWORKS</code>
             command output.
         """
-        return self.send_command("GET_NETWORK" + " " + " ".join([network_id, variable]), timeout)
+        return await self.send_command("GET_NETWORK" + " " + " ".join([network_id, variable]), timeout)
 
-    def send_command_save_config(self, timeout: float = 1) -> bytes:
+    async def send_command_save_config(self, timeout: float = 1) -> bytes:
         """Send message: SAVE_CONFIG
 
         Save the current configuration.
         """
-        return self.send_command("SAVE_CONFIG", timeout)
+        return await self.send_command("SAVE_CONFIG", timeout)
 
-    def send_command_p2p_find(self, timeout: float = 1) -> bytes:
+    async def send_command_p2p_find(self, timeout: float = 1) -> bytes:
         """Send message: P2P_FIND
 
         The default search type is to first run a full scan of all channels and
@@ -334,25 +335,25 @@ class WPASupplicant:
             the GO being asleep) over time without adding considerable extra
             delay for every Search state round.
         """
-        return self.send_command("P2P_FIND", timeout)
+        return await self.send_command("P2P_FIND", timeout)
 
-    def send_command_p2p_stop_find(self, timeout: float = 1) -> bytes:
+    async def send_command_p2p_stop_find(self, timeout: float = 1) -> bytes:
         """Send message: P2P_STOP_FIND
 
         Stop ongoing P2P device discovery or other operation (connect, listen mode).
 
         """
-        return self.send_command("P2P_STOP_FIND", timeout)
+        return await self.send_command("P2P_STOP_FIND", timeout)
 
-    def send_command_p2p_connect(self, timeout: float = 1) -> bytes:
+    async def send_command_p2p_connect(self, timeout: float = 1) -> bytes:
         """Send message: P2P_CONNECT
 
         The optional "go_intent" parameter can be used to override the default
             GO Intent value.
         """
-        return self.send_command("P2P_CONNECT", timeout)
+        return await self.send_command("P2P_CONNECT", timeout)
 
-    def send_command_p2p_listen(self, timeout: float = 1) -> bytes:
+    async def send_command_p2p_listen(self, timeout: float = 1) -> bytes:
         """Send message: P2P_LISTEN
 
         Start Listen-only state. Optional parameter can be used to specify the
@@ -361,9 +362,9 @@ class WPASupplicant:
             designed for testing. It can also be used to keep the device discoverable
             without having to maintain a group.
         """
-        return self.send_command("P2P_LISTEN", timeout)
+        return await self.send_command("P2P_LISTEN", timeout)
 
-    def send_command_p2p_group_remove(self, timeout: float = 1) -> bytes:
+    async def send_command_p2p_group_remove(self, timeout: float = 1) -> bytes:
         """Send message: P2P_GROUP_REMOVE
 
         Terminate a P2P group. If a new virtual network interface was used for
@@ -371,9 +372,9 @@ class WPASupplicant:
             of the group interface is used as a parameter for this command.
 
         """
-        return self.send_command("P2P_GROUP_REMOVE", timeout)
+        return await self.send_command("P2P_GROUP_REMOVE", timeout)
 
-    def send_command_p2p_group_add(self, timeout: float = 1) -> bytes:
+    async def send_command_p2p_group_add(self, timeout: float = 1) -> bytes:
         """Send message: P2P_GROUP_ADD
 
         Set up a P2P group owner manually (i.e., without group owner negotiation
@@ -381,9 +382,9 @@ class WPASupplicant:
             persistent=<network id>=""> can be used to specify restart of a
             persistent group.
         """
-        return self.send_command("P2P_GROUP_ADD", timeout)
+        return await self.send_command("P2P_GROUP_ADD", timeout)
 
-    def send_command_p2p_prov_disc(self, timeout: float = 1) -> bytes:
+    async def send_command_p2p_prov_disc(self, timeout: float = 1) -> bytes:
         """Send message: P2P_PROV_DISC
 
         Send P2P provision discovery request to the specified peer. The parameters
@@ -393,20 +394,20 @@ class WPASupplicant:
             02:01:02:03:04:05 keypad" would request the peer to enter a PIN
             that we display.
         """
-        return self.send_command("P2P_PROV_DISC", timeout)
+        return await self.send_command("P2P_PROV_DISC", timeout)
 
-    def send_command_p2p_get_passphrase(self, timeout: float = 1) -> bytes:
+    async def send_command_p2p_get_passphrase(self, timeout: float = 1) -> bytes:
         """Send message: P2P_GET_PASSPHRASE
 
         Get the passphrase for a group (only available when acting as a GO).
         """
-        return self.send_command("P2P_GET_PASSPHRASE", timeout)
+        return await self.send_command("P2P_GET_PASSPHRASE", timeout)
 
-    def send_command_p2p_serv_disc_req(self, timeout: float = 1) -> bytes:
+    async def send_command_p2p_serv_disc_req(self, timeout: float = 1) -> bytes:
         """Send message: P2P-SERV-DISC-REQ"""
-        return self.send_command("P2P-SERV-DISC-REQ", timeout)
+        return await self.send_command("P2P-SERV-DISC-REQ", timeout)
 
-    def send_command_p2p_serv_disc_cancel_req(self, timeout: float = 1) -> bytes:
+    async def send_command_p2p_serv_disc_cancel_req(self, timeout: float = 1) -> bytes:
         """Send message: P2P_SERV_DISC_CANCEL_REQ
 
         Cancel a pending P2P service discovery request. This command takes a single
@@ -414,22 +415,22 @@ class WPASupplicant:
             by  <a class="el" href="ctrl_iface_page.html#ctrl_iface_P2P_SERV_DISC_REQ">P2P_SERV_DISC_REQ</a>
             ), e.g., "P2P_SERV_DISC_CANCEL_REQ 1f77628".
         """
-        return self.send_command("P2P_SERV_DISC_CANCEL_REQ", timeout)
+        return await self.send_command("P2P_SERV_DISC_CANCEL_REQ", timeout)
 
-    def send_command_p2p_serv_disc_resp(self, timeout: float = 1) -> bytes:
+    async def send_command_p2p_serv_disc_resp(self, timeout: float = 1) -> bytes:
         """Send message: P2P-SERV-DISC-RESP"""
-        return self.send_command("P2P-SERV-DISC-RESP", timeout)
+        return await self.send_command("P2P-SERV-DISC-RESP", timeout)
 
-    def send_command_p2p_service_update(self, timeout: float = 1) -> bytes:
+    async def send_command_p2p_service_update(self, timeout: float = 1) -> bytes:
         """Send message: P2P_SERVICE_UPDATE
 
         Indicate that local services have changed. This is used to increment the
             P2P service indicator value so that peers know when previously
             cached information may have changed.
         """
-        return self.send_command("P2P_SERVICE_UPDATE", timeout)
+        return await self.send_command("P2P_SERVICE_UPDATE", timeout)
 
-    def send_command_p2p_serv_disc_external(self, timeout: float = 1) -> bytes:
+    async def send_command_p2p_serv_disc_external(self, timeout: float = 1) -> bytes:
         """Send message: P2P_SERV_DISC_EXTERNAL
 
         Configure external processing of P2P service requests: 0 (default) = no
@@ -439,9 +440,9 @@ class WPASupplicant:
             <a class="el" href="ctrl_iface_page.html#ctrl_iface_P2P_SERV_DISC_RESP">P2P_SERV_DISC_RESP</a>
             ).
         """
-        return self.send_command("P2P_SERV_DISC_EXTERNAL", timeout)
+        return await self.send_command("P2P_SERV_DISC_EXTERNAL", timeout)
 
-    def send_command_p2p_reject(self, timeout: float = 1) -> bytes:
+    async def send_command_p2p_reject(self, timeout: float = 1) -> bytes:
         """Send message: P2P_REJECT
 
         Reject connection attempt from a peer (specified with a device address).
@@ -449,16 +450,16 @@ class WPASupplicant:
             and request to automatically block any further connection or discovery
             of the peer.
         """
-        return self.send_command("P2P_REJECT", timeout)
+        return await self.send_command("P2P_REJECT", timeout)
 
-    def send_command_p2p_invite(self, timeout: float = 1) -> bytes:
+    async def send_command_p2p_invite(self, timeout: float = 1) -> bytes:
         """Send message: P2P_INVITE
 
         Invite a peer to join a group or to (re)start a persistent group.
         """
-        return self.send_command("P2P_INVITE", timeout)
+        return await self.send_command("P2P_INVITE", timeout)
 
-    def send_command_p2p_peer(self, timeout: float = 1) -> bytes:
+    async def send_command_p2p_peer(self, timeout: float = 1) -> bytes:
         """Send message: P2P_PEER
 
         Fetch information about a discovered peer. This command takes in an argument
@@ -467,23 +468,23 @@ class WPASupplicant:
             Address>" to indicate the entry following the specified peer (to
             allow for iterating through the list).
         """
-        return self.send_command("P2P_PEER", timeout)
+        return await self.send_command("P2P_PEER", timeout)
 
-    def send_command_p2p_ext_listen(self, timeout: float = 1) -> bytes:
+    async def send_command_p2p_ext_listen(self, timeout: float = 1) -> bytes:
         """Send message: P2P_EXT_LISTEN
 
         And a matching reply from the GUI:
         """
-        return self.send_command("P2P_EXT_LISTEN", timeout)
+        return await self.send_command("P2P_EXT_LISTEN", timeout)
 
-    def send_command_get_capability(self, option: str, strict: str = "", timeout: float = 1) -> bytes:
+    async def send_command_get_capability(self, option: str, strict: str = "", timeout: float = 1) -> bytes:
         """Send message: GET_CAPABILITY
 
         Example request/reply pairs:
         """
-        return self.send_command("GET_CAPABILITY" + " " + " ".join([option, strict]), timeout)
+        return await self.send_command("GET_CAPABILITY" + " " + " ".join([option, strict]), timeout)
 
-    def send_command_ap_scan(self, ap_scan_value: str, timeout: float = 1) -> bytes:
+    async def send_command_ap_scan(self, ap_scan_value: str, timeout: float = 1) -> bytes:
         """Send message: AP_SCAN
 
         Change ap_scan value: 0 = no scanning, 1 = wpa_supplicant requests scans
@@ -491,218 +492,218 @@ class WPASupplicant:
             not use scanning and just requests driver to associate and take
             care of AP selection
         """
-        return self.send_command("AP_SCAN" + " " + " ".join([ap_scan_value]), timeout)
+        return await self.send_command("AP_SCAN" + " " + " ".join([ap_scan_value]), timeout)
 
-    def send_command_interfaces(self, timeout: float = 1) -> bytes:
+    async def send_command_interfaces(self, timeout: float = 1) -> bytes:
         """Send message: INTERFACES
 
         Following subsections describe the most common event notifications generated
             by wpa_supplicant.
         """
-        return self.send_command("INTERFACES", timeout)
+        return await self.send_command("INTERFACES", timeout)
 
-    def send_command_ctrl_req_(self, timeout: float = 1) -> bytes:
+    async def send_command_ctrl_req_(self, timeout: float = 1) -> bytes:
         """Send message: CTRL-REQ-
 
         WPA_CTRL_REQ: Request information from a user.
         """
-        return self.send_command("CTRL-REQ-", timeout)
+        return await self.send_command("CTRL-REQ-", timeout)
 
-    def send_command_ctrl_event_connected(self, timeout: float = 1) -> bytes:
+    async def send_command_ctrl_event_connected(self, timeout: float = 1) -> bytes:
         """Send message: CTRL-EVENT-CONNECTED
 
         WPA_EVENT_CONNECTED: Indicate successfully completed authentication and
             that the data connection is now enabled.
         """
-        return self.send_command("CTRL-EVENT-CONNECTED", timeout)
+        return await self.send_command("CTRL-EVENT-CONNECTED", timeout)
 
-    def send_command_ctrl_event_disconnected(self, timeout: float = 1) -> bytes:
+    async def send_command_ctrl_event_disconnected(self, timeout: float = 1) -> bytes:
         """Send message: CTRL-EVENT-DISCONNECTED
 
         WPA_EVENT_DISCONNECTED: Disconnected, data connection is not available
 
         """
-        return self.send_command("CTRL-EVENT-DISCONNECTED", timeout)
+        return await self.send_command("CTRL-EVENT-DISCONNECTED", timeout)
 
-    def send_command_ctrl_event_terminating(self, timeout: float = 1) -> bytes:
+    async def send_command_ctrl_event_terminating(self, timeout: float = 1) -> bytes:
         """Send message: CTRL-EVENT-TERMINATING
 
         WPA_EVENT_TERMINATING: wpa_supplicant is exiting
         """
-        return self.send_command("CTRL-EVENT-TERMINATING", timeout)
+        return await self.send_command("CTRL-EVENT-TERMINATING", timeout)
 
-    def send_command_ctrl_event_password_changed(self, timeout: float = 1) -> bytes:
+    async def send_command_ctrl_event_password_changed(self, timeout: float = 1) -> bytes:
         """Send message: CTRL-EVENT-PASSWORD-CHANGED
 
         WPA_EVENT_PASSWORD_CHANGED: Password change was completed successfully
 
         """
-        return self.send_command("CTRL-EVENT-PASSWORD-CHANGED", timeout)
+        return await self.send_command("CTRL-EVENT-PASSWORD-CHANGED", timeout)
 
-    def send_command_ctrl_event_eap_notification(self, timeout: float = 1) -> bytes:
+    async def send_command_ctrl_event_eap_notification(self, timeout: float = 1) -> bytes:
         """Send message: CTRL-EVENT-EAP-NOTIFICATION
 
         WPA_EVENT_EAP_NOTIFICATION: EAP-Request/Notification received
         """
-        return self.send_command("CTRL-EVENT-EAP-NOTIFICATION", timeout)
+        return await self.send_command("CTRL-EVENT-EAP-NOTIFICATION", timeout)
 
-    def send_command_ctrl_event_eap_started(self, timeout: float = 1) -> bytes:
+    async def send_command_ctrl_event_eap_started(self, timeout: float = 1) -> bytes:
         """Send message: CTRL-EVENT-EAP-STARTED
 
         WPA_EVENT_EAP_STARTED: EAP authentication started (EAP-Request/Identity
             received)
         """
-        return self.send_command("CTRL-EVENT-EAP-STARTED", timeout)
+        return await self.send_command("CTRL-EVENT-EAP-STARTED", timeout)
 
-    def send_command_ctrl_event_eap_method(self, timeout: float = 1) -> bytes:
+    async def send_command_ctrl_event_eap_method(self, timeout: float = 1) -> bytes:
         """Send message: CTRL-EVENT-EAP-METHOD
 
         WPA_EVENT_EAP_METHOD: EAP method selected
         """
-        return self.send_command("CTRL-EVENT-EAP-METHOD", timeout)
+        return await self.send_command("CTRL-EVENT-EAP-METHOD", timeout)
 
-    def send_command_ctrl_event_eap_success(self, timeout: float = 1) -> bytes:
+    async def send_command_ctrl_event_eap_success(self, timeout: float = 1) -> bytes:
         """Send message: CTRL-EVENT-EAP-SUCCESS
 
         WPA_EVENT_EAP_SUCCESS: EAP authentication completed successfully
         """
-        return self.send_command("CTRL-EVENT-EAP-SUCCESS", timeout)
+        return await self.send_command("CTRL-EVENT-EAP-SUCCESS", timeout)
 
-    def send_command_ctrl_event_eap_failure(self, timeout: float = 1) -> bytes:
+    async def send_command_ctrl_event_eap_failure(self, timeout: float = 1) -> bytes:
         """Send message: CTRL-EVENT-EAP-FAILURE
 
         WPA_EVENT_EAP_FAILURE: EAP authentication failed (EAP-Failure received)
 
         """
-        return self.send_command("CTRL-EVENT-EAP-FAILURE", timeout)
+        return await self.send_command("CTRL-EVENT-EAP-FAILURE", timeout)
 
-    def send_command_ctrl_event_scan_results(self, timeout: float = 1) -> bytes:
+    async def send_command_ctrl_event_scan_results(self, timeout: float = 1) -> bytes:
         """Send message: CTRL-EVENT-SCAN-RESULTS
 
         WPA_EVENT_SCAN_RESULTS: New scan results available
         """
-        return self.send_command("CTRL-EVENT-SCAN-RESULTS", timeout)
+        return await self.send_command("CTRL-EVENT-SCAN-RESULTS", timeout)
 
-    def send_command_ctrl_event_bss_added(self, timeout: float = 1) -> bytes:
+    async def send_command_ctrl_event_bss_added(self, timeout: float = 1) -> bytes:
         """Send message: CTRL-EVENT-BSS-ADDED
 
         WPA_EVENT_BSS_ADDED: A new BSS entry was added. The event prefix is followed
             by the BSS entry id and BSSID.
         """
-        return self.send_command("CTRL-EVENT-BSS-ADDED", timeout)
+        return await self.send_command("CTRL-EVENT-BSS-ADDED", timeout)
 
-    def send_command_ctrl_event_bss_removed(self, timeout: float = 1) -> bytes:
+    async def send_command_ctrl_event_bss_removed(self, timeout: float = 1) -> bytes:
         """Send message: CTRL-EVENT-BSS-REMOVED
 
         WPA_EVENT_BSS_REMOVED: A BSS entry was removed. The event prefix is followed
             by BSS entry id and BSSID.
         """
-        return self.send_command("CTRL-EVENT-BSS-REMOVED", timeout)
+        return await self.send_command("CTRL-EVENT-BSS-REMOVED", timeout)
 
-    def send_command_wps_overlap_detected(self, timeout: float = 1) -> bytes:
+    async def send_command_wps_overlap_detected(self, timeout: float = 1) -> bytes:
         """Send message: WPS-OVERLAP-DETECTED
 
         WPS_EVENT_OVERLAP: WPS overlap detected in PBC mode
         """
-        return self.send_command("WPS-OVERLAP-DETECTED", timeout)
+        return await self.send_command("WPS-OVERLAP-DETECTED", timeout)
 
-    def send_command_wps_ap_available_pbc(self, timeout: float = 1) -> bytes:
+    async def send_command_wps_ap_available_pbc(self, timeout: float = 1) -> bytes:
         """Send message: WPS-AP-AVAILABLE-PBC
 
         WPS_EVENT_AP_AVAILABLE_PBC: Available WPS AP with active PBC found in scan
             results.
         """
-        return self.send_command("WPS-AP-AVAILABLE-PBC", timeout)
+        return await self.send_command("WPS-AP-AVAILABLE-PBC", timeout)
 
-    def send_command_wps_ap_available_pin(self, timeout: float = 1) -> bytes:
+    async def send_command_wps_ap_available_pin(self, timeout: float = 1) -> bytes:
         """Send message: WPS-AP-AVAILABLE-PIN
 
         WPS_EVENT_AP_AVAILABLE_PIN: Available WPS AP with recently selected PIN
             registrar found in scan results.
         """
-        return self.send_command("WPS-AP-AVAILABLE-PIN", timeout)
+        return await self.send_command("WPS-AP-AVAILABLE-PIN", timeout)
 
-    def send_command_wps_ap_available(self, timeout: float = 1) -> bytes:
+    async def send_command_wps_ap_available(self, timeout: float = 1) -> bytes:
         """Send message: WPS-AP-AVAILABLE
 
         WPS_EVENT_AP_AVAILABLE: Available WPS AP found in scan results
         """
-        return self.send_command("WPS-AP-AVAILABLE", timeout)
+        return await self.send_command("WPS-AP-AVAILABLE", timeout)
 
-    def send_command_wps_cred_received(self, timeout: float = 1) -> bytes:
+    async def send_command_wps_cred_received(self, timeout: float = 1) -> bytes:
         """Send message: WPS-CRED-RECEIVED
 
         WPS_EVENT_CRED_RECEIVED: A new credential received
         """
-        return self.send_command("WPS-CRED-RECEIVED", timeout)
+        return await self.send_command("WPS-CRED-RECEIVED", timeout)
 
-    def send_command_wps_m2d(self, timeout: float = 1) -> bytes:
+    async def send_command_wps_m2d(self, timeout: float = 1) -> bytes:
         """Send message: WPS-M2D
 
         WPS_EVENT_M2D: M2D received
         """
-        return self.send_command("WPS-M2D", timeout)
+        return await self.send_command("WPS-M2D", timeout)
 
-    def send_command_ctrl_iface_event_wps_fail(self, timeout: float = 1) -> bytes:
+    async def send_command_ctrl_iface_event_wps_fail(self, timeout: float = 1) -> bytes:
         """Send message: ctrl_iface_event_WPS_FAIL
 
         WPS_EVENT_FAIL: WPS registration failed after M2/M2D
         """
-        return self.send_command("ctrl_iface_event_WPS_FAIL", timeout)
+        return await self.send_command("ctrl_iface_event_WPS_FAIL", timeout)
 
-    def send_command_wps_success(self, timeout: float = 1) -> bytes:
+    async def send_command_wps_success(self, timeout: float = 1) -> bytes:
         """Send message: WPS-SUCCESS
 
         WPS_EVENT_SUCCESS: WPS registration completed successfully
         """
-        return self.send_command("WPS-SUCCESS", timeout)
+        return await self.send_command("WPS-SUCCESS", timeout)
 
-    def send_command_wps_timeout(self, timeout: float = 1) -> bytes:
+    async def send_command_wps_timeout(self, timeout: float = 1) -> bytes:
         """Send message: WPS-TIMEOUT
 
         WPS_EVENT_TIMEOUT: WPS enrollment attempt timed out and was terminated
 
         """
-        return self.send_command("WPS-TIMEOUT", timeout)
+        return await self.send_command("WPS-TIMEOUT", timeout)
 
-    def send_command_wps_enrollee_seen(self, timeout: float = 1) -> bytes:
+    async def send_command_wps_enrollee_seen(self, timeout: float = 1) -> bytes:
         """Send message: WPS-ENROLLEE-SEEN
 
         WPS_EVENT_ENROLLEE_SEEN: WPS Enrollee was detected (used in AP mode). The
             event prefix is followed by MAC addr, UUID-E, pri dev type, config
             methods, dev passwd id, request type, [dev name].
         """
-        return self.send_command("WPS-ENROLLEE-SEEN", timeout)
+        return await self.send_command("WPS-ENROLLEE-SEEN", timeout)
 
-    def send_command_wps_er_ap_add(self, timeout: float = 1) -> bytes:
+    async def send_command_wps_er_ap_add(self, timeout: float = 1) -> bytes:
         """Send message: WPS-ER-AP-ADD
 
         WPS_EVENT_ER_AP_ADD: WPS ER discovered an AP
         """
-        return self.send_command("WPS-ER-AP-ADD", timeout)
+        return await self.send_command("WPS-ER-AP-ADD", timeout)
 
-    def send_command_wps_er_ap_remove(self, timeout: float = 1) -> bytes:
+    async def send_command_wps_er_ap_remove(self, timeout: float = 1) -> bytes:
         """Send message: WPS-ER-AP-REMOVE
 
         WPS_EVENT_ER_AP_REMOVE: WPS ER removed an AP entry
         """
-        return self.send_command("WPS-ER-AP-REMOVE", timeout)
+        return await self.send_command("WPS-ER-AP-REMOVE", timeout)
 
-    def send_command_wps_er_enrollee_add(self, timeout: float = 1) -> bytes:
+    async def send_command_wps_er_enrollee_add(self, timeout: float = 1) -> bytes:
         """Send message: WPS-ER-ENROLLEE-ADD
 
         WPS_EVENT_ER_ENROLLEE_ADD: WPS ER discovered a new Enrollee
         """
-        return self.send_command("WPS-ER-ENROLLEE-ADD", timeout)
+        return await self.send_command("WPS-ER-ENROLLEE-ADD", timeout)
 
-    def send_command_wps_er_enrollee_remove(self, timeout: float = 1) -> bytes:
+    async def send_command_wps_er_enrollee_remove(self, timeout: float = 1) -> bytes:
         """Send message: WPS-ER-ENROLLEE-REMOVE
 
         WPS_EVENT_ER_ENROLLEE_REMOVE: WPS ER removed an Enrollee entry
         """
-        return self.send_command("WPS-ER-ENROLLEE-REMOVE", timeout)
+        return await self.send_command("WPS-ER-ENROLLEE-REMOVE", timeout)
 
-    def send_command_wps_pin_needed(self, timeout: float = 1) -> bytes:
+    async def send_command_wps_pin_needed(self, timeout: float = 1) -> bytes:
         """Send message: WPS-PIN-NEEDED
 
         WPS_EVENT_PIN_NEEDED: PIN is needed to complete provisioning with an Enrollee.
@@ -710,95 +711,95 @@ class WPASupplicant:
             device name, manufacturer, model name, model number, serial number,
             primary device type).
         """
-        return self.send_command("WPS-PIN-NEEDED", timeout)
+        return await self.send_command("WPS-PIN-NEEDED", timeout)
 
-    def send_command_wps_new_ap_settings(self, timeout: float = 1) -> bytes:
+    async def send_command_wps_new_ap_settings(self, timeout: float = 1) -> bytes:
         """Send message: WPS-NEW-AP-SETTINGS
 
         WPS_EVENT_NEW_AP_SETTINGS: New AP settings were received
         """
-        return self.send_command("WPS-NEW-AP-SETTINGS", timeout)
+        return await self.send_command("WPS-NEW-AP-SETTINGS", timeout)
 
-    def send_command_wps_reg_success(self, timeout: float = 1) -> bytes:
+    async def send_command_wps_reg_success(self, timeout: float = 1) -> bytes:
         """Send message: WPS-REG-SUCCESS
 
         WPS_EVENT_REG_SUCCESS: WPS provisioning was completed successfully (AP/Registrar)
 
         """
-        return self.send_command("WPS-REG-SUCCESS", timeout)
+        return await self.send_command("WPS-REG-SUCCESS", timeout)
 
-    def send_command_wps_ap_setup_locked(self, timeout: float = 1) -> bytes:
+    async def send_command_wps_ap_setup_locked(self, timeout: float = 1) -> bytes:
         """Send message: WPS-AP-SETUP-LOCKED
 
         WPS_EVENT_AP_SETUP_LOCKED: AP changed into setup locked state due to multiple
             failed configuration attempts using the AP PIN.
         """
-        return self.send_command("WPS-AP-SETUP-LOCKED", timeout)
+        return await self.send_command("WPS-AP-SETUP-LOCKED", timeout)
 
-    def send_command_ap_sta_connected(self, timeout: float = 1) -> bytes:
+    async def send_command_ap_sta_connected(self, timeout: float = 1) -> bytes:
         """Send message: AP-STA-CONNECTED
 
         AP_STA_CONNECTED: A station associated with us (AP mode event). The event
             prefix is followed by the MAC address of the station.
         """
-        return self.send_command("AP-STA-CONNECTED", timeout)
+        return await self.send_command("AP-STA-CONNECTED", timeout)
 
-    def send_command_ap_sta_disconnected(self, timeout: float = 1) -> bytes:
+    async def send_command_ap_sta_disconnected(self, timeout: float = 1) -> bytes:
         """Send message: AP-STA-DISCONNECTED
 
         AP_STA_DISCONNECTED: A station disassociated (AP mode event)
         """
-        return self.send_command("AP-STA-DISCONNECTED", timeout)
+        return await self.send_command("AP-STA-DISCONNECTED", timeout)
 
-    def send_command_p2p_device_found(self, timeout: float = 1) -> bytes:
+    async def send_command_p2p_device_found(self, timeout: float = 1) -> bytes:
         """Send message: P2P-DEVICE-FOUND
 
         P2P_EVENT_DEVICE_FOUND: Indication of a discovered P2P device with information
             about that device.
         """
-        return self.send_command("P2P-DEVICE-FOUND", timeout)
+        return await self.send_command("P2P-DEVICE-FOUND", timeout)
 
-    def send_command_p2p_go_neg_request(self, timeout: float = 1) -> bytes:
+    async def send_command_p2p_go_neg_request(self, timeout: float = 1) -> bytes:
         """Send message: P2P-GO-NEG-REQUEST
 
         P2P_EVENT_GO_NEG_REQUEST: A P2P device requested GO negotiation, but we
             were not ready to start the negotiation.
         """
-        return self.send_command("P2P-GO-NEG-REQUEST", timeout)
+        return await self.send_command("P2P-GO-NEG-REQUEST", timeout)
 
-    def send_command_p2p_go_neg_success(self, timeout: float = 1) -> bytes:
+    async def send_command_p2p_go_neg_success(self, timeout: float = 1) -> bytes:
         """Send message: P2P-GO-NEG-SUCCESS
 
         P2P_EVENT_GO_NEG_SUCCESS: Indication of successfully complete group owner
             negotiation.
         """
-        return self.send_command("P2P-GO-NEG-SUCCESS", timeout)
+        return await self.send_command("P2P-GO-NEG-SUCCESS", timeout)
 
-    def send_command_p2p_go_neg_failure(self, timeout: float = 1) -> bytes:
+    async def send_command_p2p_go_neg_failure(self, timeout: float = 1) -> bytes:
         """Send message: P2P-GO-NEG-FAILURE
 
         P2P_EVENT_GO_NEG_FAILURE: Indication of failed group owner negotiation.
 
         """
-        return self.send_command("P2P-GO-NEG-FAILURE", timeout)
+        return await self.send_command("P2P-GO-NEG-FAILURE", timeout)
 
-    def send_command_p2p_group_formation_success(self, timeout: float = 1) -> bytes:
+    async def send_command_p2p_group_formation_success(self, timeout: float = 1) -> bytes:
         """Send message: P2P-GROUP-FORMATION-SUCCESS
 
         P2P_EVENT_GROUP_FORMATION_SUCCESS: Indication that P2P group formation
             has been completed successfully.
         """
-        return self.send_command("P2P-GROUP-FORMATION-SUCCESS", timeout)
+        return await self.send_command("P2P-GROUP-FORMATION-SUCCESS", timeout)
 
-    def send_command_p2p_group_formation_failure(self, timeout: float = 1) -> bytes:
+    async def send_command_p2p_group_formation_failure(self, timeout: float = 1) -> bytes:
         """Send message: P2P-GROUP-FORMATION-FAILURE
 
         P2P_EVENT_GROUP_FORMATION_FAILURE: Indication that P2P group formation
             failed (e.g., due to provisioning failure or timeout).
         """
-        return self.send_command("P2P-GROUP-FORMATION-FAILURE", timeout)
+        return await self.send_command("P2P-GROUP-FORMATION-FAILURE", timeout)
 
-    def send_command_p2p_group_started(self, timeout: float = 1) -> bytes:
+    async def send_command_p2p_group_started(self, timeout: float = 1) -> bytes:
         """Send message: P2P-GROUP-STARTED
 
         P2P_EVENT_GROUP_STARTED: Indication of a new P2P group having been started.
@@ -807,18 +808,18 @@ class WPASupplicant:
             here if known (on GO) or PSK (on client). If the group is a persistent
             one, a flag indicating that is included.
         """
-        return self.send_command("P2P-GROUP-STARTED", timeout)
+        return await self.send_command("P2P-GROUP-STARTED", timeout)
 
-    def send_command_p2p_group_removed(self, timeout: float = 1) -> bytes:
+    async def send_command_p2p_group_removed(self, timeout: float = 1) -> bytes:
         """Send message: P2P-GROUP-REMOVED
 
         P2P_EVENT_GROUP_REMOVED: Indication of a P2P group having been removed.
             Additional parameters: network interface name for the group, role
             (GO/client).
         """
-        return self.send_command("P2P-GROUP-REMOVED", timeout)
+        return await self.send_command("P2P-GROUP-REMOVED", timeout)
 
-    def send_command_p2p_prov_disc_show_pin(self, timeout: float = 1) -> bytes:
+    async def send_command_p2p_prov_disc_show_pin(self, timeout: float = 1) -> bytes:
         """Send message: P2P-PROV-DISC-SHOW-PIN
 
         P2P_EVENT_PROV_DISC_SHOW_PIN: Request from the peer for us to display a
@@ -828,18 +829,18 @@ class WPASupplicant:
             can be used to accept the request with the same PIN configured
             for the connection.
         """
-        return self.send_command("P2P-PROV-DISC-SHOW-PIN", timeout)
+        return await self.send_command("P2P-PROV-DISC-SHOW-PIN", timeout)
 
-    def send_command_p2p_prov_disc_enter_pin(self, timeout: float = 1) -> bytes:
+    async def send_command_p2p_prov_disc_enter_pin(self, timeout: float = 1) -> bytes:
         """Send message: P2P-PROV-DISC-ENTER-PIN
 
         P2P_EVENT_PROV_DISC_ENTER_PIN: Request from the peer for us to enter a
             PIN displayed on the peer. The following parameter is included
             after the event prefix: peer address.
         """
-        return self.send_command("P2P-PROV-DISC-ENTER-PIN", timeout)
+        return await self.send_command("P2P-PROV-DISC-ENTER-PIN", timeout)
 
-    def send_command_p2p_prov_disc_pbc_req(self, timeout: float = 1) -> bytes:
+    async def send_command_p2p_prov_disc_pbc_req(self, timeout: float = 1) -> bytes:
         """Send message: P2P-PROV-DISC-PBC-REQ
 
         P2P_EVENT_PROV_DISC_PBC_REQ: Request from the peer for us to connect using
@@ -847,9 +848,9 @@ class WPASupplicant:
             peer_address. P2P_CONNECT command can be used to accept the request.
 
         """
-        return self.send_command("P2P-PROV-DISC-PBC-REQ", timeout)
+        return await self.send_command("P2P-PROV-DISC-PBC-REQ", timeout)
 
-    def send_command_p2p_prov_disc_pbc_resp(self, timeout: float = 1) -> bytes:
+    async def send_command_p2p_prov_disc_pbc_resp(self, timeout: float = 1) -> bytes:
         """Send message: P2P-PROV-DISC-PBC-RESP
 
         P2P-SERV-DISC-RESP: Indicate reception of a P2P service discovery response.
@@ -857,24 +858,24 @@ class WPASupplicant:
             address, Service Update Indicator, Service Response TLV(s) as hexdump.
 
         """
-        return self.send_command("P2P-PROV-DISC-PBC-RESP", timeout)
+        return await self.send_command("P2P-PROV-DISC-PBC-RESP", timeout)
 
-    def send_command_p2p_invitation_received(self, timeout: float = 1) -> bytes:
+    async def send_command_p2p_invitation_received(self, timeout: float = 1) -> bytes:
         """Send message: P2P-INVITATION-RECEIVED
 
         P2P-INVITATION-RECEIVED: Indicate reception of a P2P Invitation Request.
             For persistent groups, the parameter after the event prefix indicates
             which network block includes the persistent group data.
         """
-        return self.send_command("P2P-INVITATION-RECEIVED", timeout)
+        return await self.send_command("P2P-INVITATION-RECEIVED", timeout)
 
-    def send_command_p2p_invitation_result(self, timeout: float = 1) -> bytes:
+    async def send_command_p2p_invitation_result(self, timeout: float = 1) -> bytes:
         """Send message: P2P-INVITATION-RESULT
 
         shows the status code returned by the peer (or -1 on local failure or timeout).
 
         """
-        return self.send_command("P2P-INVITATION-RESULT", timeout)
+        return await self.send_command("P2P-INVITATION-RESULT", timeout)
 
 
 if __name__ == "__main__":

--- a/core/services/wifi/wpa_supplicant.py
+++ b/core/services/wifi/wpa_supplicant.py
@@ -6,7 +6,7 @@ import time
 from pathlib import Path
 from typing import Optional, Tuple, Union
 
-from exceptions import BusyError, SockCommError
+from exceptions import BusyError, SockCommError, WPAOperationFail
 
 
 class WPASupplicant:
@@ -76,6 +76,9 @@ class WPASupplicant:
 
         if self.verbose and data:
             print("<", data.decode("utf-8").strip())
+
+        if data == b"FAIL":
+            raise WPAOperationFail(f"WPA operation {command} failed.")
 
         return data
 

--- a/core/services/wifi/wpa_supplicant.py
+++ b/core/services/wifi/wpa_supplicant.py
@@ -130,7 +130,7 @@ class WPASupplicant:
 
         Example command:
         """
-        return await self.send_command("SET" + " " + " ".join([variable, value]), timeout)
+        return await self.send_command(f"SET {variable} {value}", timeout)
 
     async def send_command_logon(self, timeout: float = 1) -> bytes:
         """Send message: LOGON
@@ -166,7 +166,7 @@ class WPASupplicant:
 
         Start pre-authentication with the given BSSID.
         """
-        return await self.send_command("PREAUTH" + " " + " ".join([BSSID]), timeout)
+        return await self.send_command(f"PREAUTH {BSSID}", timeout)
 
     async def send_command_attach(self, timeout: float = 1) -> bytes:
         """Send message: ATTACH
@@ -191,7 +191,7 @@ class WPASupplicant:
 
         Change debug level.
         """
-        return await self.send_command("LEVEL" + " " + " ".join([debug_level]), timeout)
+        return await self.send_command(f"LEVEL {debug_level}", timeout)
 
     async def send_command_reconfigure(self, timeout: float = 1) -> bytes:
         """Send message: RECONFIGURE
@@ -213,7 +213,7 @@ class WPASupplicant:
         Set preferred BSSID for a network. Network id can be received from the
             <code>LIST_NETWORKS</code>  command output.
         """
-        return await self.send_command("BSSID" + " " + " ".join([network_id, BSSID]), timeout)
+        return await self.send_command(f"BSSID {network_id} {BSSID}", timeout)
 
     async def send_command_list_networks(self, timeout: float = 1) -> bytes:
         """Send message: LIST_NETWORKS
@@ -260,7 +260,7 @@ class WPASupplicant:
         Select a network (disable others). Network id can be received from the
             <code>LIST_NETWORKS</code>  command output.
         """
-        return await self.send_command("SELECT_NETWORK" + " " + " ".join([network_id]), timeout)
+        return await self.send_command(f"SELECT_NETWORK {network_id}", timeout)
 
     async def send_command_enable_network(self, network_id: str, timeout: float = 1) -> bytes:
         """Send message: ENABLE_NETWORK
@@ -269,7 +269,7 @@ class WPASupplicant:
             command output. Special network id  <code>all</code>  can be used
             to enable all network.
         """
-        return await self.send_command("ENABLE_NETWORK" + " " + " ".join([network_id]), timeout)
+        return await self.send_command(f"ENABLE_NETWORK {network_id}", timeout)
 
     async def send_command_disable_network(self, network_id: str, timeout: float = 1) -> bytes:
         """Send message: DISABLE_NETWORK
@@ -278,7 +278,7 @@ class WPASupplicant:
             command output. Special network id  <code>all</code>  can be used
             to disable all network.
         """
-        return await self.send_command("DISABLE_NETWORK" + " " + " ".join([network_id]), timeout)
+        return await self.send_command(f"DISABLE_NETWORK {network_id}", timeout)
 
     async def send_command_add_network(self, timeout: float = 1) -> bytes:
         """Send message: ADD_NETWORK
@@ -298,7 +298,7 @@ class WPASupplicant:
             command output. Special network id  <code>all</code>  can be used
             to remove all network.
         """
-        return await self.send_command("REMOVE_NETWORK" + " " + " ".join([network_id]), timeout)
+        return await self.send_command(f"REMOVE_NETWORK {network_id}", timeout)
 
     async def send_command_set_network(self, network_id: str, variable: str, value: str, timeout: float = 1) -> bytes:
         """Send message: SET_NETWORK
@@ -306,7 +306,7 @@ class WPASupplicant:
         This command uses the same variables and data formats as the configuration
             file. See example wpa_supplicant.conf for more details.
         """
-        return await self.send_command("SET_NETWORK" + " " + " ".join([network_id, variable, value]), timeout)
+        return await self.send_command(f"SET_NETWORK {network_id} {variable} {value}", timeout)
 
     async def send_command_get_network(self, network_id: str, variable: str, timeout: float = 1) -> bytes:
         """Send message: GET_NETWORK
@@ -314,7 +314,7 @@ class WPASupplicant:
         Get network variables. Network id can be received from the  <code>LIST_NETWORKS</code>
             command output.
         """
-        return await self.send_command("GET_NETWORK" + " " + " ".join([network_id, variable]), timeout)
+        return await self.send_command(f"GET_NETWORK {network_id} {variable}", timeout)
 
     async def send_command_save_config(self, timeout: float = 1) -> bytes:
         """Send message: SAVE_CONFIG
@@ -485,7 +485,7 @@ class WPASupplicant:
 
         Example request/reply pairs:
         """
-        return await self.send_command("GET_CAPABILITY" + " " + " ".join([option, strict]), timeout)
+        return await self.send_command(f"GET_CAPABILITY {option} {strict}", timeout)
 
     async def send_command_ap_scan(self, ap_scan_value: str, timeout: float = 1) -> bytes:
         """Send message: AP_SCAN
@@ -495,7 +495,7 @@ class WPASupplicant:
             not use scanning and just requests driver to associate and take
             care of AP selection
         """
-        return await self.send_command("AP_SCAN" + " " + " ".join([ap_scan_value]), timeout)
+        return await self.send_command(f"AP_SCAN {ap_scan_value}", timeout)
 
     async def send_command_interfaces(self, timeout: float = 1) -> bytes:
         """Send message: INTERFACES


### PR DESCRIPTION
Definitely a big refactor, but a much needed one.
Among the changes:
- Introduces timeouts for WPA operations (they could be slow or busy sometimes, making requests fail)
- Everything is async now (YES!) (scan operations, which can take from 5 to 15 seconds do not block other requests anymore)
- Scan logic is refactored so in-progress scan results are used on new fetchs (e.g: 10 requests will not necessarily create 10 scan operations. If there's one scan happening when you make a request, its result will be used)
- Network-registering is now separated from network-connecting, so new connections to known/saved networks don't create infinite new entries
- We can now connect to unprotected networks
- We can now forget saved networks
- Connections are now forced by default (currently if there were two known networks nearby and you were connected in one of them, you couldn't connect on the other)
- Allow connecting to hidden networks
- Improved readability on some stuff

Fix #294 
Fix #211 
Fix #238 