### PR TITLE
bcm_27xx.sh: set baudrate on i2c buses

### DIFF
--- a/install/boards/bcm_27xx.sh
+++ b/install/boards/bcm_27xx.sh
@@ -34,9 +34,9 @@ for STRING in \
     "dtoverlay=uart4" \
     "dtoverlay=uart5" \
     "dtparam=i2c_vc=on" \
-    "dtoverlay=i2c1" \
-    "dtoverlay=i2c4,pins_6_7" \
-    "dtoverlay=i2c6,pins_22_23" \
+    "dtoverlay=i2c1,baudrate=1000000" \
+    "dtoverlay=i2c4,pins_6_7,baudrate=1000000" \
+    "dtoverlay=i2c6,pins_22_23,baudrate=1000000" \
     "dtparam=spi=on" \
     "dtoverlay=spi0-led" \
     "dtoverlay=spi1-3cs" \


### PR DESCRIPTION
This is important for ardusub to run at full speed. Without this,
setting sched_loop_rate to 400hz would only achieve 200Hz at best.

tested with `SCHED_DEBUG = 2`
before:
```
APM: PERF: 2849/4000 [18697:2343] F=201Hz sd=3240 Ex=550
APM: PERF: 2857/4000 [18224:2266] F=199Hz sd=3232 Ex=700
``` 
after:
```
APM: PERF: 0/4000 [2950:2272] F=400Hz sd=15 Ex=0
APM: PERF: 1/4000 [3742:1259] F=400Hz sd=33 Ex=0
APM: PERF: 14/4000 [7834:908] F=400Hz sd=122 Ex=0
APM: PERF: 37/4000 [4941:917] F=393Hz sd=102 Ex=0
``` 
it is not perfect yet, but it is a lot closer.

Also. these tests were on a preempt_rt kernel. We need to test the regular one.