### PR TITLE
Update mavlink2rest to the latest version 

### DIFF
--- a/core/start-companion-core
+++ b/core/start-companion-core
@@ -4,13 +4,18 @@ COMPANION_PATH=/home/pi
 SERVICES_PATH=$COMPANION_PATH/services
 TOOLS_PATH=$COMPANION_PATH/tools
 
+# MAVLink configuration
+MAV_SYSTEM_ID=1
+## We use the last ID for the companion computer component reserved address for our usage
+MAV_COMPONENT_ID_ONBOARD_COMPUTER4=194
+
 SERVICES=(
     'cable_guy',"$SERVICES_PATH/cable_guy/main.py"
     'wifi',"$SERVICES_PATH/wifi/main.py --socket wlan0"
     'autopilot',"$SERVICES_PATH/ardupilot_manager/main.py"
     'helper',"$SERVICES_PATH/helper/main.py"
     'video',"mavlink-camera-manager --default-settings BlueROVUDP --verbose"
-    'mavlink2rest',"mavlink2rest --connect=udpin:127.0.0.1:14000 --server 0.0.0.0:6040"
+    'mavlink2rest',"mavlink2rest --connect=udpin:127.0.0.1:14000 --server 0.0.0.0:6040 --system-id $MAV_SYSTEM_ID --component-id $MAV_COMPONENT_ID_ONBOARD_COMPUTER4"
     'linux2rest',"linux2rest"
     'filebrowser',"filebrowser --database /etc/filebrowser/filebrowser.db"
     'versionchooser',"$SERVICES_PATH/versionchooser/main.py"

--- a/core/tools/mavlink2rest/bootstrap.sh
+++ b/core/tools/mavlink2rest/bootstrap.sh
@@ -2,7 +2,7 @@
 
 LOCAL_BINARY_PATH="/usr/bin/mavlink2rest"
 
-VERSION=t0.11.1
+VERSION=t0.11.2
 
 # By default we install armv7
 REMOTE_BINARY_URL="https://github.com/patrickelectric/mavlink2rest/releases/download/${VERSION}/mavlink2rest-armv7-unknown-linux-musleabihf"


### PR DESCRIPTION
- Fix problems related to the failsafe mechanism where mavlink2rest was using 255 system id 