### PR TITLE
Add Wifi manager to main frontend

### DIFF
--- a/core/frontend/src/App.vue
+++ b/core/frontend/src/App.vue
@@ -14,6 +14,7 @@
 
         <v-spacer />
 
+        <wifi-tray-menu />
         <notification-tray-button />
       </v-app-bar>
     </v-card>
@@ -73,6 +74,7 @@ import Vue from 'vue'
 
 import NotificationTrayButton from './components/notifications/TrayButton.vue'
 import ServicesScanner from './components/scanner/servicesScanner.vue'
+import WifiTrayMenu from './components/wifi/WifiTrayMenu.vue'
 
 export default Vue.extend({
   name: 'App',
@@ -80,6 +82,7 @@ export default Vue.extend({
   components: {
     'notification-tray-button': NotificationTrayButton,
     'services-scanner': ServicesScanner,
+    'wifi-tray-menu': WifiTrayMenu,
   },
 
   data: () => ({

--- a/core/frontend/src/components/common/PasswordInput.vue
+++ b/core/frontend/src/components/common/PasswordInput.vue
@@ -1,0 +1,54 @@
+<template>
+  <v-text-field
+    :value="value"
+    :append-icon="password_show_icon"
+    :type="input_field_type"
+    label="Password"
+    hide-details="auto"
+    class="pa-2"
+    @input="emitInput"
+    @keyup.enter="emitSubmit"
+    @click:append="togglePasswordShow"
+  />
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+
+export default Vue.extend({
+  name: 'PasswordInput',
+  props: {
+    value: {
+      type: String,
+      default: '',
+    },
+  },
+  data() {
+    return {
+      show_password: false,
+    }
+  },
+  computed: {
+    password_show_icon(): string {
+      return this.show_password ? 'mdi-eye' : 'mdi-eye-off'
+    },
+    input_field_type(): string {
+      return this.show_password ? 'text' : 'password'
+    },
+  },
+  methods: {
+    togglePasswordShow() {
+      this.show_password = !this.show_password
+    },
+    emitInput(value: string) {
+      this.$emit('input', value)
+    },
+    emitSubmit() {
+      this.$emit('submit')
+    },
+  },
+})
+</script>
+
+<style>
+</style>

--- a/core/frontend/src/components/common/SpinningLogo.vue
+++ b/core/frontend/src/components/common/SpinningLogo.vue
@@ -1,0 +1,34 @@
+<template>
+  <v-img
+    class="lds-dual-ring"
+    src="../../assets/logo.svg"
+  />
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+
+export default Vue.extend({
+  name: 'SpinningLogo',
+})
+</script>
+
+<style>
+  .lds-dual-ring {
+    display: block;
+    width: 30%;
+    height: 30%;
+    margin: 5% auto;
+    animation-name: rotation360;
+    animation-duration: 2s;
+    animation-iteration-count: infinite;
+  }
+  @keyframes rotation360 {
+    0% {
+        transform: rotate(0deg);
+    }
+    100% {
+        transform: rotate(360deg);
+    }
+  }
+</style>

--- a/core/frontend/src/components/wifi/ConnectionDialog.vue
+++ b/core/frontend/src/components/wifi/ConnectionDialog.vue
@@ -1,0 +1,222 @@
+<template>
+  <v-dialog
+    width="300"
+    :value="show"
+    @input="showDialog"
+  >
+    <v-card>
+      <v-card-title>
+        {{ real_ssid }}
+
+        <v-spacer />
+
+        <v-btn
+          icon
+          @click="toggleInfoShow()"
+        >
+          <v-icon>{{ show_more_info_icon }}</v-icon>
+        </v-btn>
+      </v-card-title>
+
+      <v-expand-transition>
+        <div v-show="show_more_info">
+          <v-card-text>
+            <v-simple-table
+              dense
+            >
+              <template #default>
+                <tbody>
+                  <tr
+                    v-for="(value, name) in network"
+                    :key="name"
+                  >
+                    <td>{{ name }}</td>
+                    <td>{{ value }}</td>
+                  </tr>
+                </tbody>
+              </template>
+            </v-simple-table>
+          </v-card-text>
+        </div>
+      </v-expand-transition>
+
+      <v-card-actions class="d-flex flex-column">
+        <v-container>
+          <v-row>
+            <v-text-field
+              v-if="is_hidden"
+              v-model="inputed_ssid"
+              label="SSID"
+              hide-details="auto"
+              class="pa-2"
+            />
+          </v-row>
+
+          <v-row>
+            <v-card
+              v-if="!show_password_input_box"
+              elevation="0"
+              @click="toggleForcePassword()"
+            >
+              <v-card-text>
+                Force new password
+              </v-card-text>
+            </v-card>
+            <password-input
+              v-if="show_password_input_box"
+              v-model="password"
+              @submit="connectToWifiNetwork"
+            />
+          </v-row>
+
+          <v-row
+            class="d-flex justify-space-around py-4"
+          >
+            <v-btn
+              v-if="network.saved"
+              dark
+              color="red lighten-1"
+              depressed
+              @click="removeSavedWifiNetwork"
+            >
+              Forget
+            </v-btn>
+
+            <v-btn
+              dark
+              color="blue darken-1"
+              depressed
+              @click="connectToWifiNetwork"
+            >
+              Connect
+            </v-btn>
+          </v-row>
+        </v-container>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script lang="ts">
+import axios from 'axios'
+import Vue, { PropType } from 'vue'
+import { getModule } from 'vuex-module-decorators'
+
+import NotificationsStore from '@/store/notifications'
+import WifiStore from '@/store/wifi'
+import { wifi_service } from '@/types/frontend_services'
+import { LiveNotification, NotificationLevel } from '@/types/notifications'
+import { Network, NetworkCredentials } from '@/types/wifi.d'
+
+import PasswordInput from '../common/PasswordInput.vue'
+
+const notification_store: NotificationsStore = getModule(NotificationsStore)
+const wifi_store: WifiStore = getModule(WifiStore)
+
+export default Vue.extend({
+  name: 'ConnectionDialog',
+  components: {
+    PasswordInput,
+  },
+  model: {
+    prop: 'show',
+    event: 'change',
+  },
+  props: {
+    network: {
+      type: Object as PropType<Network>,
+      required: true,
+    },
+    show: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  data() {
+    return {
+      password: '',
+      force_password: false,
+      inputed_ssid: 'HIDDEN SSID',
+      show_more_info: false,
+    }
+  },
+  computed: {
+    show_more_info_icon(): string {
+      return this.show_more_info ? 'mdi-chevron-up' : 'mdi-information'
+    },
+    real_ssid(): string {
+      return this.is_hidden ? this.inputed_ssid : this.network.ssid
+    },
+    is_hidden(): boolean {
+      return this.network.ssid === null || this.network.ssid === ''
+    },
+    show_password_input_box(): boolean {
+      if (this.force_password) {
+        return true
+      }
+      if (this.network.saved || !this.network.locked) {
+        return false
+      }
+      return true
+    },
+  },
+  methods: {
+    toggleInfoShow(): void {
+      this.show_more_info = !this.show_more_info
+    },
+    toggleForcePassword(): void {
+      this.force_password = !this.force_password
+    },
+    async connectToWifiNetwork(): Promise<void> {
+      const credentials: NetworkCredentials = { ssid: this.real_ssid, password: this.password }
+      await axios({
+        method: 'post',
+        url: `${wifi_store.API_URL}/connect`,
+        timeout: 2000,
+        data: credentials,
+        params: { hidden: this.is_hidden },
+      })
+        .then(() => {
+          wifi_store.setNetworkStatus(null)
+        })
+        .catch((error) => {
+          notification_store.pushNotification(new LiveNotification(
+            NotificationLevel.Error,
+            wifi_service,
+            'WIFI_CONNECT_FAIL',
+            `Could not connect to wifi network: ${error.message}.`,
+          ))
+        })
+        .finally(() => {
+          this.password = ''
+          this.showDialog(false)
+        })
+    },
+    async removeSavedWifiNetwork(): Promise<void> {
+      await axios({
+        method: 'post',
+        url: `${wifi_store.API_URL}/remove`,
+        timeout: 10000,
+        params: { ssid: this.network.ssid },
+      })
+        .catch((error) => {
+          notification_store.pushNotification(new LiveNotification(
+            NotificationLevel.Error,
+            wifi_service,
+            'WIFI_FORGET_FAIL',
+            `Could not remove saved wifi network: ${error.message}.`,
+          ))
+        })
+        .finally(() => {
+          this.showDialog(false)
+        })
+    },
+    showDialog(state: boolean) {
+      this.$emit('change', state)
+    },
+  },
+})
+</script>
+
+<style>
+</style>

--- a/core/frontend/src/components/wifi/DisconnectionDialog.vue
+++ b/core/frontend/src/components/wifi/DisconnectionDialog.vue
@@ -1,0 +1,141 @@
+<template>
+  <v-dialog
+    width="500"
+    :value="show"
+    @input="showDialog"
+  >
+    <v-card>
+      <v-card-title class="text-h5">
+        {{ network.ssid }}
+
+        <v-spacer />
+
+        <v-btn
+          icon
+          @click="toggleInfoShow()"
+        >
+          <v-icon>{{ show_more_info_icon }}</v-icon>
+        </v-btn>
+      </v-card-title>
+
+      <v-expand-transition>
+        <div v-show="show_more_info">
+          <v-card-text>
+            <v-simple-table
+              dense
+            >
+              <template #default>
+                <tbody>
+                  <tr
+                    v-for="(value, name) in connection_info"
+                    :key="name"
+                  >
+                    <td>{{ name }}</td>
+                    <td>{{ value }}</td>
+                  </tr>
+                </tbody>
+              </template>
+            </v-simple-table>
+          </v-card-text>
+        </div>
+      </v-expand-transition>
+
+      <v-card-actions class="d-flex flex-column py-6">
+        <v-btn
+          elevation="1"
+          dark
+          color="red darken-1"
+          @click="disconnectFromWifiNetwork"
+        >
+          Disconnect
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script lang="ts">
+import axios from 'axios'
+import Vue, { PropType } from 'vue'
+import { getModule } from 'vuex-module-decorators'
+
+import NotificationStore from '@/store/notifications'
+import WifiStore from '@/store/wifi'
+import { wifi_service } from '@/types/frontend_services'
+import { LiveNotification, NotificationLevel } from '@/types/notifications'
+import { Network, WifiStatus } from '@/types/wifi.d'
+
+const notification_store: NotificationStore = getModule(NotificationStore)
+const wifi_store: WifiStore = getModule(WifiStore)
+
+export default Vue.extend({
+  name: 'DisconnectionDialog',
+  model: {
+    prop: 'show',
+    event: 'change',
+  },
+  props: {
+    network: {
+      type: Object as PropType<Network>,
+      required: true,
+    },
+    status: {
+      type: Object as PropType<WifiStatus | null>,
+      required: true,
+    },
+    show: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  data() {
+    return {
+      show_more_info: false,
+    }
+  },
+  computed: {
+    show_more_info_icon(): string {
+      return this.show_more_info ? 'mdi-chevron-up' : 'mdi-information'
+    },
+    connection_info(): Network | (Network & WifiStatus) {
+      if (this.status === null) {
+        return this.network
+      }
+      return { ...this.network, ...this.status }
+    },
+  },
+  methods: {
+    toggleInfoShow(): void {
+      this.show_more_info = !this.show_more_info
+    },
+    async disconnectFromWifiNetwork(): Promise<void> {
+      await axios({
+        method: 'get',
+        url: `${wifi_store.API_URL}/disconnect`,
+        timeout: 10000,
+      })
+        .then(() => {
+          wifi_store.setNetworkStatus(null)
+          wifi_store.setCurrentNetwork(null)
+        })
+        .catch((error) => {
+          notification_store.pushNotification(new LiveNotification(
+            NotificationLevel.Error,
+            wifi_service,
+            'WIFI_DISCONNECT_FAIL',
+            `Could not disconnect from wifi network: ${error.message}.`,
+          ))
+        })
+        .finally(() => {
+          this.showDialog(false)
+        })
+    },
+    showDialog(state: boolean): void {
+      this.$emit('change', state)
+    },
+  },
+})
+</script>
+
+<style>
+</style>

--- a/core/frontend/src/components/wifi/NetworkCard.vue
+++ b/core/frontend/src/components/wifi/NetworkCard.vue
@@ -1,0 +1,88 @@
+<template>
+  <v-row
+    flat
+    @click="emitClick"
+  >
+    <v-col :cols="1" />
+
+    <v-col :cols="7">
+      {{ network_name }}
+    </v-col>
+
+    <v-col :cols="1">
+      <v-icon class="d-flex flex-justify-center">
+        {{ network_saved_icon }}
+      </v-icon>
+    </v-col>
+
+    <v-col :cols="1">
+      <v-icon class="d-flex flex-justify-center">
+        {{ network_protection_icon }}
+      </v-icon>
+    </v-col>
+
+    <v-col :cols="1">
+      <v-icon class="d-flex flex-justify-center">
+        {{ signal_strength_icon }}
+      </v-icon>
+    </v-col>
+
+    <v-col :cols="1" />
+  </v-row>
+</template>
+
+<script lang="ts">
+import Vue, { PropType } from 'vue'
+
+import { Network } from '@/types/wifi.d'
+
+export default Vue.extend({
+  name: 'NetworkCard',
+  props: {
+    network: {
+      type: Object as PropType<Network>,
+      required: true,
+    },
+  },
+  computed: {
+    network_saved_icon(): string {
+      return this.network.saved ? 'mdi-content-save' : ''
+    },
+    network_name(): string {
+      if (this.network.ssid === null || this.network.ssid === '') {
+        return '[HIDDEN SSID]'
+      }
+      return this.network.ssid
+    },
+    network_protection_icon(): string {
+      return this.network.locked ? 'mdi-lock' : 'mdi-lock-open-outline'
+    },
+    signal_strength_icon(): string {
+      /*eslint-disable */
+      // | Signal Strength | TL;DR     |  Description                                                                                                                               |
+      // |-----------------|-----------|--------------------------------------------------------------------------------------------------------------------------------------------|
+      // | -30 dBm         | Amazing   | Max achievable signal strength. The client can only be a few feet from the AP to achieve this. Not typical or desirable in the real world. |
+      // | -67 dBm         | Very Good | Minimum signal strength for applications that require very reliable, timely delivery of data packets.                                      |
+      // | -70 dBm         | Okay      | Minimum signal strength for reliable packet delivery.                                                                                      |
+      // | -80 dBm         | Not Good  | Minimum signal strength for basic connectivity. Packet delivery may be unreliable.                                                         |
+      // | -90 dBm         | Unusable  | Approaching or drowning in the noise floor. Any functionality is highly unlikely.                                                           |
+      // Reference: metageek.com/training/resources/wifi-signal-strength-basics.html
+      /* eslint-enable */
+
+      if (this.network.signal >= -30) return 'mdi-wifi-strength-4'
+      if (this.network.signal >= -67) return 'mdi-wifi-strength-3'
+      if (this.network.signal >= -70) return 'mdi-wifi-strength-2'
+      if (this.network.signal >= -80) return 'mdi-wifi-strength-1'
+      return 'mdi-wifi-strength-outline'
+    },
+  },
+  methods: {
+    emitClick(): void {
+      this.$emit('click', this.network)
+    },
+  },
+})
+</script>
+
+<style>
+</style>

--- a/core/frontend/src/components/wifi/WifiManager.vue
+++ b/core/frontend/src/components/wifi/WifiManager.vue
@@ -1,0 +1,124 @@
+<template>
+  <v-card
+    elevation="1"
+    width="500"
+  >
+    <v-container>
+      <v-container v-if="current_network">
+        <network-card
+          class="connected-network"
+          :network="current_network"
+          @click="openDisconnectionDialog"
+        />
+      </v-container>
+
+      <v-container v-if="are_connectable_networks_available">
+        <network-card
+          v-for="(network, key) in connectable_networks"
+          :key="key"
+          class="available-network"
+          :network="network"
+          @click="openConnectionDialog"
+        />
+      </v-container>
+      <v-container v-else>
+        <spinning-logo />
+      </v-container>
+    </v-container>
+    <wifi-updater />
+
+    <connection-dialog
+      v-if="selected_network"
+      v-model="show_connection_dialog"
+      :network="selected_network"
+    />
+
+    <disconnection-dialog
+      v-if="current_network"
+      v-model="show_disconnection_dialog"
+      :network="current_network"
+      :status="wifi_status"
+    />
+  </v-card>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import { getModule } from 'vuex-module-decorators'
+
+import WifiStore from '@/store/wifi'
+import { Network, WifiStatus } from '@/types/wifi.d'
+
+import SpinningLogo from '../common/SpinningLogo.vue'
+import ConnectionDialog from './ConnectionDialog.vue'
+import DisconnectionDialog from './DisconnectionDialog.vue'
+import NetworkCard from './NetworkCard.vue'
+import WifiUpdater from './WifiUpdater.vue'
+
+const wifi_store: WifiStore = getModule(WifiStore)
+
+export default Vue.extend({
+  name: 'WifiManager',
+  components: {
+    NetworkCard,
+    SpinningLogo,
+    ConnectionDialog,
+    DisconnectionDialog,
+    WifiUpdater,
+  },
+  data() {
+    return {
+      selected_network: null as Network | null,
+      show_connection_dialog: false,
+      show_disconnection_dialog: false,
+    }
+  },
+  computed: {
+    wifi_status(): WifiStatus | null {
+      return wifi_store.network_status
+    },
+    current_network(): Network | null {
+      return wifi_store.current_network
+    },
+    connectable_networks(): Network[] {
+      let showable_networks = wifi_store.available_networks
+      const { current_network } = wifi_store
+      if (current_network) {
+        showable_networks = showable_networks.filter((network: Network) => network.ssid !== current_network.ssid)
+      }
+      return showable_networks.sort((a: Network, b: Network) => b.signal - a.signal)
+    },
+    are_connectable_networks_available(): boolean {
+      return this.connectable_networks.length !== 0
+    },
+  },
+  methods: {
+    openConnectionDialog(network: Network): void {
+      this.selected_network = network
+      this.show_connection_dialog = true
+    },
+    openDisconnectionDialog(): void {
+      this.show_disconnection_dialog = true
+    },
+  },
+})
+</script>
+
+<style>
+  .connected-network {
+      background-color: #2799D2
+  }
+
+  .connected-network:hover {
+      cursor: pointer;
+  }
+
+  .available-network {
+      background-color: #f8f8f8;
+  }
+
+  .available-network:hover {
+      cursor: pointer;
+      background-color: #c5c5c5;
+  }
+</style>

--- a/core/frontend/src/components/wifi/WifiTrayMenu.vue
+++ b/core/frontend/src/components/wifi/WifiTrayMenu.vue
@@ -1,0 +1,40 @@
+<template>
+  <v-menu
+    :close-on-content-click="false"
+    nudge-left="500"
+    nudge-bottom="25"
+  >
+    <template
+      #activator="{ on, attrs }"
+    >
+      <v-card
+        class="px-1"
+        elevation="0"
+        color="transparent"
+        v-bind="attrs"
+        v-on="on"
+      >
+        <v-icon color="white">
+          mdi-wifi
+        </v-icon>
+      </v-card>
+    </template>
+    <wifi-manager />
+  </v-menu>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+
+import WifiManager from './WifiManager.vue'
+
+export default Vue.extend({
+  name: 'WifiTrayMenu',
+  components: {
+    WifiManager,
+  },
+})
+</script>
+
+<style>
+</style>

--- a/core/frontend/src/components/wifi/WifiUpdater.vue
+++ b/core/frontend/src/components/wifi/WifiUpdater.vue
@@ -1,0 +1,109 @@
+<template>
+  <span />
+</template>
+
+<script lang="ts">
+import axios, { AxiosResponse } from 'axios'
+import Vue from 'vue'
+import { getModule } from 'vuex-module-decorators'
+
+import NotificationsStore from '@/store/notifications'
+import WifiStore from '@/store/wifi'
+import { wifi_service } from '@/types/frontend_services'
+import { LiveNotification, NotificationLevel } from '@/types/notifications'
+import { SavedNetwork, WPANetwork } from '@/types/wifi.d'
+import { callPeriodically } from '@/utils/helper_functions'
+
+const notification_store: NotificationsStore = getModule(NotificationsStore)
+const wifi_store: WifiStore = getModule(WifiStore)
+
+export default Vue.extend({
+  name: 'WifiUpdater',
+  async mounted() {
+    await callPeriodically(this.fetchSavedNetworks, 5000)
+    await callPeriodically(this.fetchNetworkStatus, 5000)
+    await callPeriodically(this.fetchAvailableNetworks, 10000)
+  },
+  methods: {
+    async fetchNetworkStatus(): Promise<void> {
+      await axios({
+        method: 'get',
+        url: `${wifi_store.API_URL}/status`,
+        timeout: 10000,
+      })
+        .then((response: AxiosResponse) => {
+          wifi_store.setNetworkStatus(response.data)
+
+          if (response.data.wpa_state !== 'COMPLETED') {
+            wifi_store.setCurrentNetwork(null)
+            return
+          }
+
+          const scanned_network = wifi_store.available_networks.find((network) => network.ssid === response.data.ssid)
+          const saved_network = wifi_store.saved_networks.find((network) => network.ssid === response.data.ssid)
+
+          wifi_store.setCurrentNetwork({
+            ssid: response.data.ssid,
+            signal: scanned_network ? scanned_network.signal : 0,
+            locked: response.data.key_mgmt.includes('WPA'),
+            saved: saved_network != null,
+          })
+        })
+        .catch((error) => {
+          wifi_store.setCurrentNetwork(null)
+          notification_store.pushNotification(new LiveNotification(
+            NotificationLevel.Error,
+            wifi_service,
+            'WIFI_STATUS_FETCH_FAIL',
+            `Could not fetch wifi status: ${error.message}`,
+          ))
+        })
+    },
+    async fetchAvailableNetworks(): Promise<void> {
+      await axios({
+        method: 'get',
+        url: `${wifi_store.API_URL}/scan`,
+        timeout: 20000,
+      })
+        .then((response) => {
+          const saved_networks_ssids = wifi_store.saved_networks.map((network: SavedNetwork) => network.ssid)
+          const available_networks = response.data.map((network: WPANetwork) => ({
+            ssid: network.ssid,
+            signal: network.signallevel,
+            locked: network.flags.includes('WPA'),
+            saved: saved_networks_ssids.includes(network.ssid),
+          }))
+          wifi_store.setAvailableNetworks(available_networks)
+        })
+        .catch((error) => {
+          wifi_store.setAvailableNetworks([])
+          notification_store.pushNotification(new LiveNotification(
+            NotificationLevel.Error,
+            wifi_service,
+            'WIFI_SCAN_FAIL',
+            `Could not scan for wifi networks: ${error.message}`,
+          ))
+        })
+    },
+    async fetchSavedNetworks(): Promise<void> {
+      await axios({
+        method: 'get',
+        url: `${wifi_store.API_URL}/saved`,
+        timeout: 10000,
+      })
+        .then((response) => {
+          wifi_store.setSavedNetworks(response.data)
+        })
+        .catch((error) => {
+          wifi_store.setSavedNetworks([])
+          notification_store.pushNotification(new LiveNotification(
+            NotificationLevel.Error,
+            wifi_service,
+            'WIFI_SAVED_FETCH_FAIL',
+            `Could not fetch saved networks: ${error.message}.`,
+          ))
+        })
+    },
+  },
+})
+</script>

--- a/core/frontend/src/store/wifi.ts
+++ b/core/frontend/src/store/wifi.ts
@@ -1,0 +1,42 @@
+import { Module, Mutation, VuexModule } from 'vuex-module-decorators'
+
+import store from '@/store'
+import { Network, SavedNetwork, WifiStatus } from '@/types/wifi.d'
+
+@Module({
+  dynamic: true,
+  store,
+  name: 'wifi_store',
+})
+
+export default class WifiStore extends VuexModule {
+  API_URL = '/wifi-manager/v1.0'
+
+  current_network: Network | null = null
+
+  available_networks: Network[] = []
+
+  saved_networks: SavedNetwork[] = []
+
+  network_status: WifiStatus | null = null
+
+  @Mutation
+  setCurrentNetwork(network: Network | null): void {
+    this.current_network = network
+  }
+
+  @Mutation
+  setAvailableNetworks(available_networks: Network[]): void {
+    this.available_networks = available_networks
+  }
+
+  @Mutation
+  setSavedNetworks(saved_networks: SavedNetwork[]): void {
+    this.saved_networks = saved_networks
+  }
+
+  @Mutation
+  setNetworkStatus(status: WifiStatus | null): void {
+    this.network_status = status
+  }
+}

--- a/core/frontend/src/types/frontend_services.ts
+++ b/core/frontend/src/types/frontend_services.ts
@@ -8,3 +8,10 @@ export const service_scanner_service: Service = {
   company: 'Blue Robotics',
   version: '0.1.0',
 }
+
+export const wifi_service: Service = {
+  name: 'Wifi Manager',
+  description: 'Service responsible for managing wifi configuration on Companion.',
+  company: 'Blue Robotics',
+  version: '0.1.0',
+}

--- a/core/frontend/src/types/wifi.d.ts
+++ b/core/frontend/src/types/wifi.d.ts
@@ -1,0 +1,43 @@
+export interface Network {
+    ssid: string
+    signal: number
+    locked: boolean
+    saved: boolean
+}
+
+export interface WifiStatus {
+    bssid: string
+    freq: number
+    ssid: string
+    id: number
+    mode: string
+    wifi_generation: number
+    pairwise_cipher: string
+    group_cipher: string
+    key_mgmt: string
+    wpa_state: string
+    ip_address: string
+    p2p_device_address: string
+    address: string
+    uuid: string
+}
+
+export interface WPANetwork {
+    ssid: string
+    bssid: string
+    flags: string
+    frequency: number
+    signallevel: number
+}
+
+export interface SavedNetwork {
+    networkid: number
+    ssid: string
+    bssid: string
+    flags: string
+}
+
+export interface NetworkCredentials {
+    ssid: string
+    password: string
+}

--- a/core/frontend/src/utils/helper_functions.ts
+++ b/core/frontend/src/utils/helper_functions.ts
@@ -1,0 +1,18 @@
+/* Asynchronously wait for a given interval. */
+/**
+ * @param interval - Time in milliseconds to wait after the previous request is done
+* */
+export function sleep(interval: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, interval))
+}
+
+/* Call a given function periodically for a given interval. */
+/**
+ * @param func - Function to be called.
+ * @param interval - Time in milliseconds to wait after the previous request is done
+* */
+export async function callPeriodically(func: () => Promise<void>, interval: number): Promise<void> {
+  await func()
+  await sleep(interval)
+  callPeriodically(func, interval)
+}


### PR DESCRIPTION
The wifi manager allows among other things:
- showing available networks (hidden or not) and it's properties;
- connecting to new networks (hidden or not);
- connect to existing networks (without pass);
- forgetting knows networks;
- forcing password change;
- disconnecting from current network;
- showing wifi adapter properties (including local IP, security type, signal level and others).

It is mobile-friendly, asynchronous and tries to follow interface patterns already familiar to most users.

Docker image available at `rafaellehmkuhl/companion-core:wifi-frontend`

Preview:
![frontend](https://user-images.githubusercontent.com/6551040/126701050-6034af9e-5024-4382-aea1-e5e76f23f0de.gif)