### PR TITLE
tools: linux2rest: Update to the last version 0.1.6

### DIFF
--- a/core/tools/linux2rest/bootstrap.sh
+++ b/core/tools/linux2rest/bootstrap.sh
@@ -4,7 +4,7 @@
 set -e
 
 LOCAL_BINARY_PATH="/usr/bin/linux2rest"
-VERSION=v0.1.4
+VERSION=v0.1.6
 
 # By default we install armv7
 REMOTE_BINARY_URL="https://github.com/patrickelectric/linux2rest/releases/download/${VERSION}/linux2rest-armv7"


### PR DESCRIPTION
- Fix github actions tag check for Cargo.toml
- Fix usage of CLI to set server port
- Fix html tags
- Set default server port to previous default port (6030)
- Use sysinfo release over master branch
- Add error message on the webpage for platform
- Update to the latest version of sysinfo
- Sort UDP by local address, TCP by local address and process by cpu on webpage