### PR TITLE
core: ardupilot-manager: Make default GCS endpoint an UDP server

### DIFF
--- a/core/frontend/src/views/MainView.vue
+++ b/core/frontend/src/views/MainView.vue
@@ -1,5 +1,21 @@
 <template>
   <v-container>
+    <v-bottom-sheet
+      :value="true"
+      inset
+    >
+      <v-card>
+        <v-card-title>Mavlink connection change</v-card-title>
+        <v-card-text>
+          New Companion doesn't provide a fixed UDP Client endpoint on 192.168.2.1 anymore. For new
+          connections Companion now provides an UDP Server locally on port 14550.
+
+          For connecting QGroundControl, for example, please go to Comm Links and create an
+          UDP endpoint pointing to companion.local or Companion's IP address (e.g.:192.168.2.2), on port 14550.
+          <v-card-text />
+        </v-card-text>
+      </v-card>
+    </v-bottom-sheet>
     <available-services-table />
   </v-container>
 </template>

--- a/core/services/ardupilot_manager/ArduPilotManager.py
+++ b/core/services/ardupilot_manager/ArduPilotManager.py
@@ -145,7 +145,12 @@ class ArduPilotManager(metaclass=Singleton):
             self.add_new_endpoints(
                 {
                     Endpoint(
-                        "GCS Link", self.settings.app_name, EndpointType.UDPClient, "192.168.2.1", 14550, protected=True
+                        "GCS Link",
+                        self.settings.app_name,
+                        EndpointType.UDPServer,
+                        "0.0.0.0",
+                        14550,
+                        protected=True,
                     )
                 }
             )


### PR DESCRIPTION
First step to solve #418 

Image available at `rafaellehmkuhl/companion-core:gcs-endpoint`