### PR TITLE
core: Add encoding argument to `with open` blocks

### DIFF
--- a/bootstrap/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap/bootstrap.py
@@ -55,7 +55,7 @@ class Bootstrapper:
         # Tries to open the current file
         config = {}
         try:
-            with open(Bootstrapper.DOCKER_CONFIG_FILE_PATH) as config_file:
+            with open(Bootstrapper.DOCKER_CONFIG_FILE_PATH, encoding="utf-8") as config_file:
                 config = json.load(config_file)
                 assert "core" in config, "missing core entry in startup.json"
                 necessary_keys = ["image", "tag", "binds", "privileged", "network"]
@@ -66,7 +66,7 @@ class Bootstrapper:
             print(f"unable to read startup.json file ({error}), reverting to defaults...")
             # Copy defaults over and read again
             Bootstrapper.overwrite_config_file_with_defaults()
-            with open(Bootstrapper.DEFAULT_FILE_PATH) as config_file:
+            with open(Bootstrapper.DEFAULT_FILE_PATH, encoding="utf-8") as config_file:
                 config = json.load(config_file)
 
         config["core"]["binds"][str(Bootstrapper.HOST_CONFIG_PATH)] = {

--- a/core/libs/commonwealth/setup.py
+++ b/core/libs/commonwealth/setup.py
@@ -7,7 +7,7 @@ import setuptools
 ## Fix problems related to calling setup.py from different paths
 os.chdir(os.path.abspath(os.path.dirname(__file__)))
 
-with open(pathlib.Path(__file__).parent.joinpath("README.md"), "r") as readme:
+with open(pathlib.Path(__file__).parent.joinpath("README.md"), "r", encoding="utf-8") as readme:
     long_description = readme.read()
 
 setuptools.setup(

--- a/core/services/ardupilot_manager/firmware_download/FirmwareDownload.py
+++ b/core/services/ardupilot_manager/firmware_download/FirmwareDownload.py
@@ -126,7 +126,7 @@ class FirmwareDownload:
             bool: True if valid, False if otherwise.
         """
         if FirmwareFormat.APJ.value in firmware_path.suffix:
-            with open(firmware_path, "r") as firmware_file:
+            with open(firmware_path, "r", encoding="utf-8") as firmware_file:
                 data = json.load(firmware_file)
                 keys = data.keys()
                 if "image_size" in keys and "image" in keys:

--- a/core/services/ardupilot_manager/settings.py
+++ b/core/services/ardupilot_manager/settings.py
@@ -34,7 +34,7 @@ class Settings:
         """Create settings file."""
         try:
             if not Path.is_file(self.settings_file):
-                with open(self.settings_file, "w+") as file:
+                with open(self.settings_file, "w+", encoding="utf-8") as file:
                     logger.info(f"Creating settings file: {self.settings_file}")
                     json.dump(self.root, file, sort_keys=True, indent=4)
 
@@ -71,7 +71,7 @@ class Settings:
 
         data = None
         try:
-            with open(self.settings_file) as file:
+            with open(self.settings_file, encoding="utf-8") as file:
                 data = json.load(file)
                 if data["version"] != self.root["version"]:
                     logger.error("User settings does not match with our supported version.")
@@ -100,7 +100,7 @@ class Settings:
         try:
             Path.mkdir(self.settings_path, exist_ok=True)
 
-            with open(self.settings_file, "w+") as file:
+            with open(self.settings_file, "w+", encoding="utf-8") as file:
                 logger.info(f"Updating settings file: {self.settings_file}")
                 json.dump(self.root, file, sort_keys=True, indent=4)
         except Exception as error:

--- a/core/services/ardupilot_manager/setup.py
+++ b/core/services/ardupilot_manager/setup.py
@@ -36,7 +36,7 @@ for filename, url in static_files.items():
         sys.exit(1)
 
 
-with open("README.md", "r") as readme:
+with open("README.md", "r", encoding="utf-8") as readme:
     long_description = readme.read()
 
 setuptools.setup(

--- a/core/services/cable_guy/api/settings.py
+++ b/core/services/cable_guy/api/settings.py
@@ -34,7 +34,7 @@ class Settings:
 
         data = None
         try:
-            with open(self.settings_file) as file:
+            with open(self.settings_file, encoding="utf-8") as file:
                 data = json.load(file)
                 if data["version"] != self.root["version"]:
                     print("User settings does not match with our supported version.")
@@ -62,6 +62,6 @@ class Settings:
         if not os.path.exists(self.settings_path):
             os.makedirs(self.settings_path)
 
-        with open(self.settings_file, "w+") as file:
+        with open(self.settings_file, "w+", encoding="utf-8") as file:
             print(f"Updating settings file: {self.settings_file}")
             json.dump(self.root, file, sort_keys=True, indent=4)

--- a/core/services/cable_guy/setup.py
+++ b/core/services/cable_guy/setup.py
@@ -50,7 +50,7 @@ def populate_static_files() -> None:
 
 populate_static_files()
 
-with open("README.md", "r") as readme:
+with open("README.md", "r", encoding="utf-8") as readme:
     long_description = readme.read()
 
 setuptools.setup(

--- a/core/services/ping/serialhelper.py
+++ b/core/services/ping/serialhelper.py
@@ -32,7 +32,7 @@ def set_low_latency(port: SysFS) -> None:
     logging.info(f"Latency file: {latency_file}")
 
     try:
-        with open(latency_file, "w") as p:
+        with open(latency_file, "w", encoding="utf-8") as p:
             p.write("1")
             p.flush()
     except IOError:

--- a/core/services/versionchooser/utils/chooser.py
+++ b/core/services/versionchooser/utils/chooser.py
@@ -31,7 +31,7 @@ class VersionChooser:
 
     @staticmethod
     def get_current_image_and_tag() -> Optional[Tuple[str, str]]:
-        with open(DOCKER_CONFIG_PATH) as startup_file:
+        with open(DOCKER_CONFIG_PATH, encoding="utf-8") as startup_file:
             try:
                 core = json.load(startup_file)["core"]
                 tag = core["tag"]
@@ -116,7 +116,7 @@ class VersionChooser:
         if not self.is_valid_version(image, tag):
             return web.Response(status=400, text="Invalid version")
 
-        with open(DOCKER_CONFIG_PATH, "r+") as startup_file:
+        with open(DOCKER_CONFIG_PATH, "r+", encoding="utf-8") as startup_file:
             try:
                 data = json.load(startup_file)
                 data["core"]["image"] = image


### PR DESCRIPTION
Last update on Pylint rules enforce explicity set of encoding type on context management blocks.