### PR TITLE
core: tools: mavlink2rest: Update mavlink2rest to t0.11.4

### DIFF
--- a/core/tools/mavlink2rest/bootstrap.sh
+++ b/core/tools/mavlink2rest/bootstrap.sh
@@ -2,7 +2,7 @@
 
 LOCAL_BINARY_PATH="/usr/bin/mavlink2rest"
 
-VERSION=t0.11.2
+VERSION=t0.11.4
 
 # By default we install armv7
 REMOTE_BINARY_URL="https://github.com/patrickelectric/mavlink2rest/releases/download/${VERSION}/mavlink2rest-armv7-unknown-linux-musleabihf"


### PR DESCRIPTION
Changes from the last version:
- Fix serial communication
- Add mavlink2 extensions back

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>