### PR TITLE
core: file-browser: Add baseurl argument on start

### DIFF
--- a/core/start-companion-core
+++ b/core/start-companion-core
@@ -25,7 +25,7 @@ SERVICES=(
     'video',"mavlink-camera-manager --default-settings BlueROVUDP --verbose"
     'mavlink2rest',"mavlink2rest --connect=udpin:127.0.0.1:14000 --server 0.0.0.0:6040 --system-id $MAV_SYSTEM_ID --component-id $MAV_COMPONENT_ID_ONBOARD_COMPUTER4"
     'linux2rest',"linux2rest"
-    'filebrowser',"filebrowser --database /etc/filebrowser/filebrowser.db"
+    'filebrowser',"filebrowser --database /etc/filebrowser/filebrowser.db --baseurl /file-browser"
     'versionchooser',"$SERVICES_PATH/versionchooser/main.py"
     'ping',"$SERVICES_PATH/ping/main.py"
     'ttyd',"ttyd -p 8088 /usr/bin/tmux"


### PR DESCRIPTION
`baseurl` argument is needed to make file-browser work properly with reverse-proxys (such as nginx).