### PR TITLE
Add Logviewer

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -21,6 +21,7 @@ RUN /home/pi/tools/ardupilot_tools/bootstrap.sh
 RUN /home/pi/tools/dnsmasq/bootstrap.sh
 RUN /home/pi/tools/filebrowser/bootstrap.sh
 RUN /home/pi/tools/linux2rest/bootstrap.sh
+RUN /home/pi/tools/logviewer/bootstrap.sh
 RUN /home/pi/tools/nginx/bootstrap.sh
 
 # Install custom libraries

--- a/core/tools/logviewer/bootstrap.sh
+++ b/core/tools/logviewer/bootstrap.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+DESTINATION_PATH="/home/pi/tools/logviewer"
+
+VERSION=v0.9.1
+
+REMOTE_URL="https://github.com/Ardupilot/UAVLogViewer/releases/download/${VERSION}/logviewer.tar.gz"
+
+# Download uncompress, and move the contents of dist to the target destination
+wget $REMOTE_URL
+tar -zxf logviewer.tar.gz
+mkdir -p $DESTINATION_PATH
+mv dist/* $DESTINATION_PATH
+rm -r dist
+rm -r logviewer.tar.gz

--- a/core/tools/nginx/nginx.conf
+++ b/core/tools/nginx/nginx.conf
@@ -113,6 +113,10 @@ http {
             proxy_pass http://127.0.0.1:81;
         }
 
+        location /logviewer {
+            root /home/pi/tools;
+        }
+
         location / {
             root /home/pi/frontend;
         }


### PR DESCRIPTION
image is up at williangalvani/companion-core:logviewer

it is served by nginx at /logviewer, and isn't picked up by the helper as it isn't an independent server.