### PR TITLE
Add log browser

### DIFF
--- a/core/frontend/src/App.vue
+++ b/core/frontend/src/App.vue
@@ -131,6 +131,11 @@ export default Vue.extend({
             icon: 'mdi-chip',
             route: '/firmware',
           },
+          {
+            title: 'Log Browser',
+            icon: 'mdi-file-multiple',
+            route: '/logs',
+          },
         ],
       },
     ],

--- a/core/frontend/src/components/logs/LogManager.vue
+++ b/core/frontend/src/components/logs/LogManager.vue
@@ -1,0 +1,157 @@
+<template>
+  <v-container>
+    <v-card
+      v-if="!fetching_logs"
+      flat
+    >
+      <v-card-title>
+        Autopilot logs
+        <v-spacer />
+        <v-btn
+          icon
+          @click="fetchAvailableLogs"
+        >
+          <v-icon>mdi-update</v-icon>
+        </v-btn>
+        <v-btn
+          icon
+          color="green darken-1"
+          :disabled="disable_batch_operations"
+          @click="downloadSelectedLogs"
+        >
+          <v-icon>mdi-download-multiple</v-icon>
+        </v-btn>
+        <v-btn
+          icon
+          color="red darken-1"
+          :disabled="disable_batch_operations"
+          @click="removeLogs"
+        >
+          <v-icon>mdi-trash-can</v-icon>
+        </v-btn>
+      </v-card-title>
+      <v-card-text>
+        <v-data-table
+          v-model="selected_logs"
+          :headers="headers"
+          :items="parsed_logs"
+          item-key="name"
+          show-select
+          :sort-by.sync="sortBy"
+          :sort-desc.sync="sortDesc"
+        >
+          <template #item.actions="{ item }">
+            <v-icon @click="replay_log(item)">
+              mdi-play
+            </v-icon>
+            <v-icon @click="downloadLogs([item])">
+              mdi-download
+            </v-icon>
+          </template>
+        </v-data-table>
+      </v-card-text>
+    </v-card>
+    <v-container v-else>
+      <spinning-logo />
+    </v-container>
+  </v-container>
+</template>
+
+<script lang="ts">
+import { format } from 'date-fns'
+import Vue from 'vue'
+
+import filebrowser from '@/libs/filebrowser'
+import { FilebrowserFile } from '@/types/filebrowser'
+
+import SpinningLogo from '../common/SpinningLogo.vue'
+
+export default Vue.extend({
+  name: 'LogManager',
+  components: {
+    SpinningLogo,
+  },
+  data() {
+    return {
+      sortBy: 'modified',
+      sortDesc: true,
+      auth_key: '',
+      available_logs: [] as FilebrowserFile[],
+      fetching_logs: false,
+      selected_logs: [] as FilebrowserFile[],
+      headers: [
+        {
+          text: 'Name',
+          align: 'start',
+          sortable: false,
+          value: 'name',
+        },
+        { text: 'Size (MB)', value: 'size' },
+        { text: 'Type', value: 'extension' },
+        { text: 'Modified', value: 'modified' },
+        {
+          text: 'Actions',
+          align: 'end',
+          sortable: false,
+          value: 'actions',
+        },
+      ],
+    }
+  },
+  computed: {
+    disable_batch_operations(): boolean {
+      return this.selected_logs.length === 0
+    },
+    parsed_logs(): FilebrowserFile[] {
+      return this.available_logs.map((log) => ({
+        ...log,
+        modified: format(new Date(log.modified), 'yyyy-MM-dd HH:mm:ss'),
+        size: log.size / 1e6,
+      }))
+    },
+    are_logs_available(): boolean {
+      return this.available_logs.length !== 0
+    },
+  },
+  async mounted() {
+    await this.fetchAvailableLogs()
+  },
+  methods: {
+    async fetchAvailableLogs(): Promise<void> {
+      const new_logs: FilebrowserFile[] = []
+      this.fetching_logs = true
+
+      const log_folders = ['/root/.config/ardupilot-manager/firmware/logs/', '/root/.config/ardupilot-manager/logs/']
+
+      for (const folder_path of log_folders) {
+        await filebrowser.fetchFolder(folder_path)
+          .then((folder) => {
+            Array.prototype.push.apply(new_logs, folder.items)
+          })
+      }
+
+      this.available_logs = new_logs.filter((log) => ['.bin', '.tlog'].includes(log.extension.toLowerCase()))
+      this.fetching_logs = false
+    },
+    downloadSelectedLogs(): void {
+      this.downloadLogs(this.selected_logs)
+      this.selected_logs = []
+    },
+    downloadLogs(logs: FilebrowserFile[]): void {
+      filebrowser.downloadFiles(logs)
+    },
+    async removeLogs(): Promise<void> {
+      if (this.selected_logs.length === 0) return
+
+      await filebrowser.deleteFiles(this.selected_logs)
+
+      await this.fetchAvailableLogs()
+      this.selected_logs = []
+    },
+    async replay_log(log: FilebrowserFile): Promise<void> {
+      const log_url = encodeURIComponent(filebrowser.singleFileRelativeURL(log))
+      window.open(`/logviewer/#/?file=${log_url}`)
+    },
+  },
+})
+</script>

--- a/core/frontend/src/libs/filebrowser.ts
+++ b/core/frontend/src/libs/filebrowser.ts
@@ -1,0 +1,153 @@
+import axios from 'axios'
+import { getModule } from 'vuex-module-decorators'
+
+import NotificationsStore from '@/store/notifications'
+import { FilebrowserCredentials, FilebrowserFile, FilebrowserFolder } from '@/types/filebrowser'
+import { filebrowser_service } from '@/types/frontend_services'
+import { LiveNotification, NotificationLevel } from '@/types/notifications'
+
+const notification_store: NotificationsStore = getModule(NotificationsStore)
+
+const filebrowser_url = '/file-browser/api'
+const filebrowser_credentials: FilebrowserCredentials = { username: '', password: '', recaptcha: '' }
+
+class Filebrowser {
+  auth_token: string | null
+
+  constructor() {
+    this.auth_token = null
+    this.update_filebrowser_token()
+  }
+
+  /* Fetch filebrowser API for a authentication token and store it.
+     This method should be called on constructor so other methods have a token to use. */
+  update_filebrowser_token(): void {
+    axios({
+      method: 'post',
+      url: `${filebrowser_url}/login`,
+      timeout: 10000,
+      data: filebrowser_credentials,
+    })
+      .then((response) => {
+        this.auth_token = response.data
+      })
+      .catch((error) => {
+        const error_message = `Could not authenticate to filebrowser API: ${error.message}`
+        notification_store.pushNotification(new LiveNotification(
+          NotificationLevel.Error,
+          filebrowser_service,
+          'FILEBROWSER_AUTH_FAIL',
+          error_message,
+        ))
+        throw new Error(error)
+      })
+  }
+
+  /* Helper to get the auth token, checking before if it was set. */
+  filebrowser_token(): string {
+    if (this.auth_token === null) {
+      this.update_filebrowser_token()
+      if (this.auth_token === null) {
+        throw new Error('Authentication token not set.')
+      }
+    }
+    return this.auth_token
+  }
+
+  /* Fetch a folder from filebrowser. */
+  /**
+   * @param folder_path - String absolute path of folder to be fetched
+   * @returns FilebrowserFolder object
+  * */
+  async fetchFolder(folder_path: string): Promise<FilebrowserFolder> {
+    return axios({
+      method: 'get',
+      url: `${filebrowser_url}/resources${folder_path}`,
+      timeout: 10000,
+      headers: { 'X-Auth': this.filebrowser_token() },
+    })
+      .then((response) => response.data)
+      .catch((error) => {
+        const error_message = `Could not fetch folder ${folder_path}: ${error.message}`
+        notification_store.pushNotification(new LiveNotification(
+          NotificationLevel.Error,
+          filebrowser_service,
+          'FOLDER_FETCH_FAIL',
+          error_message,
+        ))
+        throw new Error(error_message)
+      })
+  }
+
+  /* Delete a single file. */
+  /* Register a notification and throws if delete fails. */
+  /**
+   * @param file - FilebrowserFile object to be deleted
+  * */
+  async deleteFile(file: FilebrowserFile): Promise<void> {
+    axios({
+      method: 'delete',
+      url: `/file-browser/api/resources${file.path}`,
+      timeout: 10000,
+      headers: { 'X-Auth': this.filebrowser_token() },
+    })
+      .catch((error) => {
+        const error_message = `Could not delete file ${file.path}: ${error.message}`
+        notification_store.pushNotification(new LiveNotification(
+          NotificationLevel.Error,
+          filebrowser_service,
+          'FILE_DELETE_FAIL',
+          error_message,
+        ))
+        throw new Error(error_message)
+      })
+  }
+
+  /* Performs multiple-file delete requests. */
+  /* Will perform all possible delete operations and reject if any of them fails. */
+  /**
+   * @param files - FilebrowserFile objects to be deleted
+  * */
+  async deleteFiles(files: FilebrowserFile[]): Promise<void> {
+    const delete_promises: Promise<void>[] = []
+    files.forEach((file) => {
+      delete_promises.push(this.deleteFile(file))
+    })
+    await Promise.all(delete_promises)
+  }
+
+  /* Returns the relative URL (without hostname) of a single file. */
+  /**
+   * @param file - FilebrowserFile object
+  * */
+  singleFileRelativeURL(file: FilebrowserFile): string {
+    return `${filebrowser_url}/raw${file.path}?auth=${this.filebrowser_token()}`
+  }
+
+  /* Returns the relative URL (without hostname) of a zip of multiple files. */
+  /**
+   * @param files - FilebrowserFile objects
+  * */
+  multipleFilesRelativeURL(files: FilebrowserFile[]): string {
+    const files_arg = files.map((file) => file.path).join(',')
+    return `${filebrowser_url}/raw/?files=${files_arg}&algo=zip&auth=${this.filebrowser_token()}`
+  }
+
+  /* Download files (single or multiple). */
+  /**
+   * @param files - FilebrowserFile objects array
+  * */
+  downloadFiles(files: FilebrowserFile[]): void {
+    let url = ''
+    if (files.length === 1) {
+      url = this.singleFileRelativeURL(files[0])
+    } else {
+      url = this.multipleFilesRelativeURL(files)
+    }
+    window.open(url)
+  }
+}
+
+const filebrowser = new Filebrowser()
+
+export default filebrowser

--- a/core/frontend/src/router/index.ts
+++ b/core/frontend/src/router/index.ts
@@ -2,6 +2,7 @@ import Vue from 'vue'
 import VueRouter, { RouteConfig } from 'vue-router'
 
 import Firmware from '../views/FirmwareView.vue'
+import LogView from '../views/LogView.vue'
 import Main from '../views/MainView.vue'
 
 Vue.use(VueRouter)
@@ -16,6 +17,11 @@ const routes: Array<RouteConfig> = [
     path: '/firmware',
     name: 'Firmware',
     component: Firmware,
+  },
+  {
+    path: '/logs',
+    name: 'LogManager',
+    component: LogView,
   },
 ]
 

--- a/core/frontend/src/types/filebrowser.ts
+++ b/core/frontend/src/types/filebrowser.ts
@@ -1,0 +1,28 @@
+export interface FilebrowserFile {
+  path: string
+  name: string
+  size: number
+  extension: string
+  modified: string
+  mode: number
+  isDir: boolean
+  type: string
+}
+
+export interface FolderSorting {
+  by: string
+  asc: boolean
+}
+
+export interface FilebrowserFolder extends FilebrowserFile {
+  items: FilebrowserFile[]
+  numDirs: number
+  numFiles: number
+  sorting: FolderSorting
+}
+
+export interface FilebrowserCredentials {
+  username: string
+  password: string
+  recaptcha: string
+}

--- a/core/frontend/src/types/frontend_services.ts
+++ b/core/frontend/src/types/frontend_services.ts
@@ -27,3 +27,10 @@ export const autopilot_service: Service = {
   company: 'Blue Robotics',
   version: '0.1.0',
 }
+
+export const filebrowser_service: Service = {
+  name: 'Filebrowser',
+  description: 'File browsing service.',
+  company: 'Blue Robotics',
+  version: '0.1.0',
+}

--- a/core/frontend/src/views/LogView.vue
+++ b/core/frontend/src/views/LogView.vue
@@ -1,0 +1,16 @@
+<template>
+  <log-manager />
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+
+import LogManager from '@/components/logs/LogManager.vue'
+
+export default Vue.extend({
+  name: 'LogView',
+  components: {
+    LogManager,
+  },
+})
+</script>


### PR DESCRIPTION
Log browser allow to download, delete and play autopilot logs (both `.tlog` and `.bin`).

Log browser uses `filebrowser` API to deal with the files and `UAV Logviewer` to play them.

![image](https://user-images.githubusercontent.com/6551040/131586753-7962d6c6-aef5-42ae-8d16-84c273a74f90.png)

Docker image available at `rafaellehmkuhl/companion-core/add-log-browser`