### PR TITLE
.eslint: remove ForOFStatement restriction

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,6 +27,25 @@ module.exports = {
     'no-alert': 'off',
     'no-console': 'off',
     'no-extra-parens': ['error', 'all'],
+    // modified https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/rules/style.js#L339
+    // In our opinion, readability comes first and ForOF statements are more readable,
+    // so we remove the ForOfStatement block.
+    'no-restricted-syntax': [
+      'error',
+      {
+        selector: 'ForInStatement',
+        message: ('for..in loops iterate over the entire prototype chain, which is virtually never what you want.'
+          + 'Use Object.{keys,values,entries}, and iterate over the resulting array.'),
+      },
+      {
+        selector: 'LabeledStatement',
+        message: 'Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand.',
+      },
+      {
+        selector: 'WithStatement',
+        message: '`with` is disallowed in strict mode because it makes code impossible to predict and optimize.',
+      },
+    ],
     'no-shadow': 'off',
     'no-useless-constructor': 'off',
     semi: ['error', 'never'],


### PR DESCRIPTION
We believe ForOf statements are more readable, and readability comes first. Let the developer decide which one to use at its own discretion.