### PR TITLE
core: tools: logviewer: remove .gz files

### DIFF
--- a/core/tools/logviewer/bootstrap.sh
+++ b/core/tools/logviewer/bootstrap.sh
@@ -11,5 +11,6 @@ wget $REMOTE_URL
 tar -zxf logviewer.tar.gz
 mkdir -p $DESTINATION_PATH
 mv dist/* $DESTINATION_PATH
+find $DESTINATION_PATH -name "*.gz" -type f -delete
 rm -r dist
 rm -r logviewer.tar.gz


### PR DESCRIPTION
nginx is not set up to serve .gz files, so we delete them to save
some space (whooping 5MB)