### PR TITLE
core: tools: tlogviewer: bump version to v0.9.2

### DIFF
--- a/core/tools/logviewer/bootstrap.sh
+++ b/core/tools/logviewer/bootstrap.sh
@@ -2,7 +2,7 @@
 
 DESTINATION_PATH="/home/pi/tools/logviewer"
 
-VERSION=v0.9.1
+VERSION=v0.9.2
 
 REMOTE_URL="https://github.com/Ardupilot/UAVLogViewer/releases/download/${VERSION}/logviewer.tar.gz"
 


### PR DESCRIPTION
This fixed the issue https://github.com/ArduPilot/UAVLogViewer/issues/302
and a minor one with asset paths in dev/build modes.

image at williangalvani/companion-core:logviewer092

navigate to http://companion.local/logviewer/ and use the log in the issue to test.