### PR TITLE
core: frontend: add proxy for APIs in dev mode

### DIFF
--- a/core/frontend/package.json
+++ b/core/frontend/package.json
@@ -3,6 +3,46 @@
   "version": "0.1.0",
   "private": true,
   "vue": {
+    "devServer": {
+      "proxy": {
+        "^/ardupilot-manager": {
+          "target": "http://companion.local/"
+        },
+        "^/cable-guy": {
+          "target": "http://companion.local/"
+        },
+        "^/docker": {
+          "target": "http://companion.local/"
+        },
+        "^/file-browser": {
+          "target": "http://companion.local/"
+        },
+        "^/helper": {
+          "target": "http://companion.local/"
+        },
+        "^/logviewer": {
+          "target": "http://companion.local/"
+        },
+        "^/mavlink2rest": {
+          "target": "http://companion.local/"
+        },
+        "^/mavlink-camera-manager": {
+          "target": "http://companion.local/"
+        },
+        "^/system-information": {
+          "target": "http://companion.local/"
+        },
+        "^/terminal": {
+          "target": "http://companion.local/"
+        },
+        "^/version-chooser": {
+          "target": "http://companion.local/"
+        },
+        "^/wifi-manager": {
+          "target": "http://companion.local/"
+        }
+      }
+    },
     "transpileDependencies": [
       "vuetify",
       "vuex-module-decorators"

--- a/core/tools/nginx/nginx.conf
+++ b/core/tools/nginx/nginx.conf
@@ -34,6 +34,18 @@ http {
 
         add_header Access-Control-Allow-Origin *;
 
+        location /ardupilot-manager {
+            rewrite ^/ardupilot-manager$ /ardupilot-manager/ redirect;
+            rewrite ^/ardupilot-manager/(.*)$ /$1 break;
+            proxy_pass http://127.0.0.1:8000;
+        }
+
+        location /cable-guy {
+            rewrite ^/cable-guy$ /cable-guy/ redirect;
+            rewrite ^/cable-guy/(.*)$ /$1 break;
+            proxy_pass http://127.0.0.1:9090;
+        }
+
         location /docker {
             limit_except GET {
                 deny all;
@@ -43,11 +55,29 @@ http {
             proxy_pass http://unix:/var/run/docker.sock:/;
         }
 
+        location /file-browser {
+            rewrite ^/file-browser$ /file-browser/ redirect;
+            rewrite ^/file-browser/(.*)$ /$1 break;
+            proxy_pass http://127.0.0.1:7777;
+        }
 
-        location /version-chooser {
-            rewrite ^/version-chooser$ /version-chooser/ redirect;
-            rewrite ^/version-chooser/(.*)$ /$1 break;
-            proxy_pass http://127.0.0.1:8081;
+        location /helper {
+            rewrite ^/helper$ /helper/ redirect;
+            rewrite ^/helper/(.*)$ /$1 break;
+            proxy_pass http://127.0.0.1:81;
+        }
+
+        location /logviewer {
+            root /home/pi/tools;
+        }
+
+        location /mavlink2rest {
+            rewrite ^/mavlink2rest$ /mavlink2rest/ redirect;
+            rewrite ^/mavlink2rest/(.*)$ /$1 break;
+            proxy_pass          http://127.0.0.1:6040;
+            # next two lines are required for websockets
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "Upgrade";
         }
 
         location /mavlink-camera-manager {
@@ -65,21 +95,6 @@ http {
             proxy_set_header Connection "Upgrade";
         }
 
-        location /mavlink2rest {
-            rewrite ^/mavlink2rest$ /mavlink2rest/ redirect;
-            rewrite ^/mavlink2rest/(.*)$ /$1 break;
-            proxy_pass          http://127.0.0.1:6040;
-            # next two lines are required for websockets
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "Upgrade";
-        }
-
-        location /ardupilot-manager {
-            rewrite ^/ardupilot-manager$ /ardupilot-manager/ redirect;
-            rewrite ^/ardupilot-manager/(.*)$ /$1 break;
-            proxy_pass http://127.0.0.1:8000;
-            }
-
         location /terminal {
             rewrite ^/terminal$ /terminal/ redirect;
             rewrite ^/terminal/(.*)$ /$1 break;
@@ -89,32 +104,16 @@ http {
             proxy_set_header Connection "Upgrade";
         }
 
-        location /file-browser {
-            rewrite ^/file-browser$ /file-browser/ redirect;
-            rewrite ^/file-browser/(.*)$ /$1 break;
-            proxy_pass http://127.0.0.1:7777;
+        location /version-chooser {
+            rewrite ^/version-chooser$ /version-chooser/ redirect;
+            rewrite ^/version-chooser/(.*)$ /$1 break;
+            proxy_pass http://127.0.0.1:8081;
         }
 
         location /wifi-manager {
             rewrite ^/wifi-manager$ /wifi-manager/ redirect;
             rewrite ^/wifi-manager/(.*)$ /$1 break;
             proxy_pass http://127.0.0.1:9000;
-        }
-
-        location /cable-guy {
-            rewrite ^/cable-guy$ /cable-guy/ redirect;
-            rewrite ^/cable-guy/(.*)$ /$1 break;
-            proxy_pass http://127.0.0.1:9090;
-        }
-
-        location /helper {
-            rewrite ^/helper$ /helper/ redirect;
-            rewrite ^/helper/(.*)$ /$1 break;
-            proxy_pass http://127.0.0.1:81;
-        }
-
-        location /logviewer {
-            root /home/pi/tools;
         }
 
         location / {


### PR DESCRIPTION
This allows running the frontend in the local machine while still talking to the actual API running in the companion.