### PR TITLE
Create a Health indicator using (for now) mavlink data.

### DIFF
--- a/core/frontend/src/App.vue
+++ b/core/frontend/src/App.vue
@@ -13,7 +13,7 @@
         />
 
         <v-spacer />
-
+        <health-tray-menu />
         <wifi-tray-menu />
         <ethernet-tray-menu />
         <notification-tray-button />
@@ -74,6 +74,7 @@
 import Vue from 'vue'
 
 import EthernetTrayMenu from './components/ethernet/EthernetTrayMenu.vue'
+import HealthTrayMenu from './components/health/HealthTrayMenu.vue'
 import NotificationTrayButton from './components/notifications/TrayButton.vue'
 import ServicesScanner from './components/scanner/servicesScanner.vue'
 import WifiTrayMenu from './components/wifi/WifiTrayMenu.vue'
@@ -86,6 +87,7 @@ export default Vue.extend({
     'services-scanner': ServicesScanner,
     'wifi-tray-menu': WifiTrayMenu,
     'ethernet-tray-menu': EthernetTrayMenu,
+    'health-tray-menu': HealthTrayMenu,
   },
 
   data: () => ({

--- a/core/frontend/src/components/health/HealthTrayMenu.vue
+++ b/core/frontend/src/components/health/HealthTrayMenu.vue
@@ -1,0 +1,96 @@
+<template>
+  <v-menu
+    :close-on-content-click="false"
+    nudge-left="150"
+    nudge-bottom="25"
+  >
+    <template
+      #activator="{ on, attrs }"
+    >
+      <v-card
+        elevation="0"
+        color="transparent"
+        v-bind="attrs"
+        v-on="on"
+      >
+        <v-icon
+          class="px-1"
+          color="white"
+        >
+          mdi-submarine
+        </v-icon>
+      </v-card>
+    </template>
+
+    <v-card
+      elevation="1"
+      width="250"
+    >
+      <v-container>
+        <div>
+          <table style="width: 100%">
+            <tr>
+              <td>Core Temperature:</td>
+              <td>-- ºC</td>
+            </tr>
+            <tr>
+              <td>Voltage:</td>
+              <td>{{ batt_voltage.toFixed(2) }} V</td>
+            </tr>
+            <tr>
+              <td>Current:</td>
+              <td> {{ batt_current.toFixed(2) }} A</td>
+            </tr>
+          </table>
+        </div>
+      </v-container>
+    </v-card>
+  </v-menu>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import { getModule } from 'vuex-module-decorators'
+
+import MavlinkStore from '@/store/mavlink'
+
+const mavlink_store: MavlinkStore = getModule(MavlinkStore)
+
+export default Vue.extend({
+  name: 'HealthTrayMenu',
+  components: {
+  },
+
+  computed: {
+    batt_voltage(): number {
+      if (mavlink_store.available_messages.SYS_STATUS) {
+        const data = mavlink_store.available_messages.SYS_STATUS.messageData.voltage_battery
+        if (typeof data === 'number') {
+          return data / 1000
+        }
+      }
+      return -1
+    },
+
+    batt_current(): number {
+      if (mavlink_store.available_messages.SYS_STATUS) {
+        const data = mavlink_store.available_messages.SYS_STATUS.messageData.current_battery
+        if (typeof data === 'number') {
+          return data / 100
+        }
+      }
+      return -1
+    },
+  },
+
+  mounted() {
+    mavlink_store.setMessageRefreshRate({
+      message: 'SYS_STATUS',
+      refreshRate: 3,
+    })
+  },
+})
+</script>
+
+<style>
+</style>

--- a/core/frontend/src/libs/MAVLink2Rest/index.ts
+++ b/core/frontend/src/libs/MAVLink2Rest/index.ts
@@ -26,7 +26,9 @@ class Mavlink2RestManager {
 
   private constructor() {
     this.baseUrl = `${Mavlink2RestManager.getWebsocketPrefix()}://${window.location.host}/mavlink2rest/ws/mavlink`
-    this.baseUrlCandidates = [this.baseUrl, 'ws://localhost:8088/ws/mavlink']
+    this.baseUrlCandidates = [
+      this.baseUrl,
+    ]
     this.probeBaseUrlCandidates()
   }
 

--- a/core/frontend/src/libs/MAVLink2Rest/index.ts
+++ b/core/frontend/src/libs/MAVLink2Rest/index.ts
@@ -1,11 +1,17 @@
 /* eslint-disable  @typescript-eslint/no-explicit-any */
 // The library is an interface for MAVLink objects, messages can by of any type
 
+import axios from 'axios'
+
+import { Dictionary } from '@/types/common'
+
 import Endpoint from './Endpoint'
 import Listener from './Listener'
 
-export interface Dictionary<T> {
-  [key: string]: T;
+// Maps message names to message IDs
+// TODO: should we get this generated somehow?
+const messageId: Dictionary<number> = {
+  SYS_STATUS: 1,
 }
 
 class Mavlink2RestManager {
@@ -74,6 +80,48 @@ class Mavlink2RestManager {
     const endpoint = this.endpoints[endpointName] || this.createEndpoint(endpointName)
     this.endpoints[endpointName] = endpoint
     return endpoint.addListener()
+  }
+
+  /**
+   * Requests a message at a given rate
+   * @param  {string} messsage name
+   * @returns Listener
+   */
+  requestMessageRate(message: string, rate:number): void {
+    if (rate < 0) {
+      console.warn(`Requested invalid message rate for ${message}: ${rate}`)
+      return
+    }
+
+    const payload = {
+      header: {
+        system_id: 255,
+        component_id: 0,
+        sequence: 0,
+      },
+      message: {
+        type: 'COMMAND_LONG',
+        param1: messageId[message],
+        param2: 1000000 / rate,
+        param3: 0.0,
+        param4: 0.0,
+        param5: 0.0,
+        param6: 0.0,
+        param7: 0.0,
+        command: {
+          type: 'MAV_CMD_SET_MESSAGE_INTERVAL',
+        },
+        target_system: 0,
+        target_component: 0,
+        confirmation: 0,
+      },
+    }
+    axios.post(`${this.baseUrl}/mavlink`.replace('/ws/mavlink', '').replace('ws', 'http'), payload)
+      .then(
+        () => {
+          console.log('message rate set succesfully')
+        },
+      ).catch((error) => console.log(`unable to set message rate of ${message} to ${rate}: ${error}`))
   }
 
   /**

--- a/core/frontend/src/libs/MAVLink2Rest/index.ts
+++ b/core/frontend/src/libs/MAVLink2Rest/index.ts
@@ -4,7 +4,7 @@
 import Endpoint from './Endpoint'
 import Listener from './Listener'
 
-interface Dictionary<T> {
+export interface Dictionary<T> {
   [key: string]: T;
 }
 

--- a/core/frontend/src/store/mavlink.ts
+++ b/core/frontend/src/store/mavlink.ts
@@ -1,0 +1,58 @@
+import Vue from 'vue'
+import {
+  Action, Module, Mutation, VuexModule,
+} from 'vuex-module-decorators'
+
+import mavlink2rest from '@/libs/MAVLink2Rest'
+import Listener from '@/libs/MAVLink2Rest/Listener'
+import store from '@/store'
+import { Dictionary } from '@/types/common'
+import { MavlinkMessage } from '@/types/mavlink'
+
+interface messsageRefreshRate {
+  message: string
+  refreshRate: number
+}
+
+@Module({
+  dynamic: true,
+  store,
+  name: 'mavlink_store',
+})
+
+export default class MavlinkStore extends VuexModule {
+  available_messages: Dictionary<MavlinkMessage> = {}
+
+  message_listeners: Dictionary<Listener> = {}
+
+  @Action({ commit: 'updateMessage' })
+  setMessageRefreshRate(rate: messsageRefreshRate): void {
+    const messageName = rate.message
+    const { refreshRate } = rate
+    if (refreshRate < 0) {
+      console.warn(`invalid request rate requested for message ${messageName} : ${rate} Hz`)
+    }
+
+    mavlink2rest.requestMessageRate(messageName, refreshRate)
+    // remove any listener we currently have set
+    // Should we only replace it if someone requests a higher messageRate?
+    if (this.message_listeners[messageName]) {
+      this.message_listeners[messageName].discard()
+    }
+    // create a new listener
+    this.message_listeners[messageName] = mavlink2rest.startListening(messageName).setCallback((receivedMessage) => {
+      this.updateMessage({
+        messageName,
+        messageData: receivedMessage,
+        requestedMessageRate: refreshRate,
+      })
+    }).setFrequency(refreshRate)
+  }
+
+  @Mutation
+  updateMessage(message: MavlinkMessage): void {
+    if (message) {
+      Vue.set(this.available_messages, message.messageName, message)
+    }
+  }
+}

--- a/core/frontend/src/types/common.ts
+++ b/core/frontend/src/types/common.ts
@@ -1,4 +1,9 @@
 /** Represents a Companion service, with the necessary information to identify it on the system */
+
+export interface Dictionary<T> {
+  [key: string]: T;
+}
+
 export interface Service {
   name: string
   description: string

--- a/core/frontend/src/types/mavlink.ts
+++ b/core/frontend/src/types/mavlink.ts
@@ -1,0 +1,6 @@
+export interface MavlinkMessage {
+    messageName: string
+    messageData: {[key: string]: {value: string|number}}
+    requestedMessageRate: number
+    // achievedMessageRate: number
+}


### PR DESCRIPTION
image up at williangalvani/companion-core:mavlink

![image](https://user-images.githubusercontent.com/4013804/132377006-ee0ba0b7-4776-46cb-b8fb-3e51217eb8d2.png)

This creates a mavlink store and uses this mavlink store to fetch the data from the backend.

There's a bunch of things to consider here:

 - [ ] do we actually want a mavlink store? should we just use the mavlink lib api instead? 
 - [ ] should we have the messagename->messageid map in here?
 - others as comments in the code