### PR TITLE
Endpoints frontend

### DIFF
--- a/core/frontend/src/App.vue
+++ b/core/frontend/src/App.vue
@@ -136,6 +136,11 @@ export default Vue.extend({
             icon: 'mdi-file-multiple',
             route: '/logs',
           },
+          {
+            title: 'Endpoints',
+            icon: 'mdi-arrow-decision',
+            route: '/endpoints',
+          },
         ],
       },
     ],

--- a/core/frontend/src/components/autopilot/AutopilotManagerUpdater.vue
+++ b/core/frontend/src/components/autopilot/AutopilotManagerUpdater.vue
@@ -1,0 +1,54 @@
+<template>
+  <span />
+</template>
+
+<script lang="ts">
+import axios from 'axios'
+import Vue from 'vue'
+import { getModule } from 'vuex-module-decorators'
+
+import AutopilotManagerStore from '@/store/autopilot_manager'
+import NotificationStore from '@/store/notifications'
+import { autopilot_manager_service } from '@/types/frontend_services'
+import { LiveNotification, NotificationLevel } from '@/types/notifications'
+import { callPeriodically } from '@/utils/helper_functions'
+
+const notification_store: NotificationStore = getModule(NotificationStore)
+const autopilot_manager_store: AutopilotManagerStore = getModule(AutopilotManagerStore)
+
+/**
+ * Responsible for updating autopilot-manager-related data.
+ * This component periodically fetches external APIs to gather information
+ * related to autopilot-manager functions, like mavlink endpoints.
+ * @displayName Autopilot Updater
+ */
+
+export default Vue.extend({
+  name: 'AutopilotManagerUpdater',
+  async mounted() {
+    await callPeriodically(this.fetchAvailableEndpoints, 5000)
+  },
+  methods: {
+    async fetchAvailableEndpoints(): Promise<void> {
+      await axios({
+        method: 'get',
+        url: `${autopilot_manager_store.API_URL}/endpoints`,
+        timeout: 10000,
+      })
+        .then((response) => {
+          const available_endpoints = response.data
+          autopilot_manager_store.setAvailableEndpoints(available_endpoints)
+        })
+        .catch((error) => {
+          notification_store.pushNotification(new LiveNotification(
+            NotificationLevel.Error,
+            autopilot_manager_service,
+            'AUTOPILOT_ENDPOINT_FETCH_FAIL',
+            `Could not fetch available MAVLink endpoints: ${error.message}`,
+          ))
+          autopilot_manager_store.setAvailableEndpoints([])
+        })
+    },
+  },
+})
+</script>

--- a/core/frontend/src/components/autopilot/EndpointCard.vue
+++ b/core/frontend/src/components/autopilot/EndpointCard.vue
@@ -1,0 +1,134 @@
+<template>
+  <v-card
+    width="100%"
+    class="available-endpoint pa-0 my-4"
+  >
+    <v-card-text class="pa-2">
+      <v-container class="pa-1">
+        <v-row>
+          <v-col
+            cols="6"
+            class="pa-1"
+          >
+            <v-card class="elevation-0 d-flex flex-column align-center pa-0">
+              <p class="ma-0 pt-2 text-h5">
+                {{ endpoint.name }}
+              </p>
+              <p class="ma-0 pb-2 text-body-2">
+                {{ endpoint.owner }}
+              </p>
+            </v-card>
+          </v-col>
+          <v-col
+            cols="4"
+            class="pa-1"
+          >
+            <v-card class="elevation-0 d-flex flex-column align-center pa-0">
+              <v-simple-table
+                dense
+                class="text-center"
+              >
+                <template #default>
+                  <tbody>
+                    <tr>
+                      <td>{{ userFriendlyEndpointType(endpoint.connection_type) }}</td>
+                    </tr>
+                    <tr>
+                      <td>{{ endpoint.place }}</td>
+                    </tr>
+                    <tr>
+                      <td>{{ endpoint.argument }}</td>
+                    </tr>
+                  </tbody>
+                </template>
+              </v-simple-table>
+            </v-card>
+          </v-col>
+          <v-col
+            cols="2"
+            class="pa-1"
+          >
+            <v-card class="elevation-0 d-flex flex-column align-center pa-0">
+              <v-icon
+                class="ma-1"
+                :disabled="!endpoint.persistent"
+              >
+                mdi-content-save
+              </v-icon>
+              <v-icon
+                class="ma-1"
+                :disabled="!endpoint.protected"
+              >
+                mdi-lock
+              </v-icon>
+            </v-card>
+          </v-col>
+        </v-row>
+      </v-container>
+      <v-fab-transition>
+        <v-btn
+          color="pink"
+          fab
+          dark
+          small
+          absolute
+          bottom
+          right
+          :disabled="endpoint.protected"
+          @click="removeEndpoint"
+        >
+          <v-icon>mdi-minus</v-icon>
+        </v-btn>
+      </v-fab-transition>
+    </v-card-text>
+  </v-card>
+</template>
+
+<script lang="ts">
+import axios from 'axios'
+import Vue, { PropType } from 'vue'
+import { getModule } from 'vuex-module-decorators'
+
+import AutopilotManagerStore from '@/store/autopilot_manager'
+import NotificationStore from '@/store/notifications'
+import { AutopilotEndpoint, userFriendlyEndpointType } from '@/types/autopilot'
+import { autopilot_manager_service } from '@/types/frontend_services'
+import { LiveNotification, NotificationLevel } from '@/types/notifications'
+
+const notification_store: NotificationStore = getModule(NotificationStore)
+const autopilot_manager_store: AutopilotManagerStore = getModule(AutopilotManagerStore)
+
+export default Vue.extend({
+  name: 'EndpointCard',
+  props: {
+    endpoint: {
+      type: Object as PropType<AutopilotEndpoint>,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      userFriendlyEndpointType,
+    }
+  },
+  methods: {
+    async removeEndpoint(): Promise<void> {
+      autopilot_manager_store.setUpdatingEndpoints(true)
+      await axios({
+        method: 'delete',
+        url: `${autopilot_manager_store.API_URL}/endpoints`,
+        timeout: 10000,
+        data: [this.endpoint],
+      })
+        .catch((error) => {
+          notification_store.pushNotification(new LiveNotification(
+            NotificationLevel.Error,
+            autopilot_manager_service,
+            'AUTOPILOT_ENDPOINT_DELETE_FAIL',
+            `Could not remove endpoint: ${error.message}.`,
+          ))
+        })
+    },
+  },
+})
+</script>

--- a/core/frontend/src/components/autopilot/EndpointCreationDialog.vue
+++ b/core/frontend/src/components/autopilot/EndpointCreationDialog.vue
@@ -1,0 +1,179 @@
+<template>
+  <v-dialog
+    width="500"
+    :value="show"
+    @input="showDialog"
+  >
+    <v-card>
+      <v-card-title>
+        New endpoint
+      </v-card-title>
+
+      <v-card-text class="d-flex flex-column">
+        <v-form
+          ref="form"
+          lazy-validation
+        >
+          <v-text-field
+            v-model="endpoint.name"
+            :counter="50"
+            label="Name"
+            :rules="[validate_required_field]"
+          />
+
+          <v-text-field
+            v-model="endpoint.owner"
+            :counter="50"
+            label="Owner"
+            :rules="[validate_required_field]"
+          />
+
+          <v-select
+            v-model="endpoint.connection_type"
+            :items="endpoint_types"
+            label="Type"
+            :rules="[validate_required_field]"
+          />
+
+          <v-text-field
+            v-model="endpoint.place"
+            :rules="[validate_required_field, is_ip_address_path]"
+            label="IP/Device"
+          />
+
+          <v-text-field
+            v-model="endpoint.argument"
+            :counter="50"
+            label="Port/Baudrate"
+            :rules="[validate_required_field, is_socket_port_baudrate]"
+          />
+
+          <v-checkbox
+            v-model="endpoint.persistent"
+            label="Save endpoint between system sessions?"
+          />
+
+          <v-checkbox
+            v-model="endpoint.protected"
+            label="Protect endpoint from being deleted?"
+            disabled
+          />
+
+          <v-btn
+            color="success"
+            class="mr-4"
+            @click="createEndpoint"
+          >
+            Create
+          </v-btn>
+        </v-form>
+      </v-card-text>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script lang="ts">
+import axios from 'axios'
+import Vue from 'vue'
+import { getModule } from 'vuex-module-decorators'
+
+import AutopilotManagerStore from '@/store/autopilot_manager'
+import NotificationStore from '@/store/notifications'
+import { EndpointType, userFriendlyEndpointType } from '@/types/autopilot'
+import { autopilot_manager_service } from '@/types/frontend_services'
+import { LiveNotification, NotificationLevel } from '@/types/notifications'
+import { VForm } from '@/types/vuetify'
+import {
+  isBaudrate, isFilepath, isIntegerString, isIpAddress, isNotEmpty, isSocketPort,
+} from '@/utils/pattern_validators'
+
+const notification_store: NotificationStore = getModule(NotificationStore)
+const autopilot_manager_store: AutopilotManagerStore = getModule(AutopilotManagerStore)
+
+export default Vue.extend({
+  name: 'ConnectionDialog',
+  model: {
+    prop: 'show',
+    event: 'change',
+  },
+  props: {
+    show: {
+      type: Boolean,
+      default: false,
+    },
+  },
+
+  data() {
+    return {
+      endpoint: {
+        name: '',
+        owner: '',
+        connection_type: EndpointType.udpin,
+        place: '',
+        argument: '',
+        protected: false,
+        persistent: false,
+      },
+    }
+  },
+  computed: {
+    endpoint_types(): {value: EndpointType, text: string}[] {
+      return Object.entries(EndpointType).map(
+        (type) => ({ value: type[1], text: userFriendlyEndpointType(type[1]) }),
+      )
+    },
+    form(): VForm {
+      return this.$refs.form as VForm
+    },
+  },
+  methods: {
+    validate_required_field(input: string): (true | string) {
+      return isNotEmpty(input) ? true : 'Required field.'
+    },
+    is_ip_address_path(input: string): (true | string) {
+      return isIpAddress(input) || isFilepath(input) ? true : 'Invalid IP/Device-path.'
+    },
+    is_socket_port_baudrate(input: string): (true | string) {
+      if (!isIntegerString(input)) {
+        return 'Please use an integer value.'
+      }
+      const int_input = parseInt(input, 10)
+      return isSocketPort(int_input) || isBaudrate(int_input) ? true : 'Invalid Port/Baudrate.'
+    },
+    async createEndpoint(): Promise<boolean> {
+      // Validate form before proceeding with API request
+      if (!this.form.validate()) {
+        return false
+      }
+
+      autopilot_manager_store.setUpdatingEndpoints(true)
+      this.showDialog(false)
+
+      await axios({
+        method: 'post',
+        url: `${autopilot_manager_store.API_URL}/endpoints`,
+        timeout: 10000,
+        data: [this.endpoint],
+      })
+        .then(() => {
+          this.form.reset()
+        })
+        .catch((error) => {
+          notification_store.pushNotification(new LiveNotification(
+            NotificationLevel.Error,
+            autopilot_manager_service,
+            'AUTOPILOT_ENDPOINT_CREATE_FAIL',
+            `Could not create endpoint: ${error.message}.`,
+          ))
+        })
+      return true
+    },
+    showDialog(state: boolean) {
+      this.$emit('change', state)
+    },
+  },
+})
+</script>
+
+<style>
+</style>

--- a/core/frontend/src/components/autopilot/EndpointManager.vue
+++ b/core/frontend/src/components/autopilot/EndpointManager.vue
@@ -1,0 +1,107 @@
+<template>
+  <v-card
+    width="500"
+    elevation="0"
+    class="mb-12 pb-12 endpoints-list"
+  >
+    <v-list
+      v-if="available_endpoints && !updating_endpoints"
+      dense
+    >
+      <template v-for="(endpoint, index) in available_endpoints">
+        <v-divider
+          v-if="index!==0"
+          :key="index"
+        />
+        <v-list-item
+          :key="index"
+          class="pa-0"
+        >
+          <endpoint-card :endpoint="endpoint" />
+        </v-list-item>
+      </template>
+    </v-list>
+
+    <v-container v-else-if="updating_endpoints">
+      <spinning-logo />
+    </v-container>
+    <v-container v-else>
+      <div>
+        No endpoints available
+      </div>
+    </v-container>
+
+    <v-fab-transition>
+      <v-btn
+        :key="'create_button'"
+        :color="'blue'"
+        fab
+        large
+        dark
+        fixed
+        bottom
+        right
+        class="v-btn--example"
+        @click="openCreationDialog"
+      >
+        <v-icon>mdi-plus</v-icon>
+      </v-btn>
+    </v-fab-transition>
+
+    <creation-dialog
+      v-model="show_creation_dialog"
+    />
+
+    <autopilot-manager-updater />
+  </v-card>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import { getModule } from 'vuex-module-decorators'
+
+import AutopilotManagerStore from '@/store/autopilot_manager'
+import { AutopilotEndpoint } from '@/types/autopilot'
+
+import SpinningLogo from '../common/SpinningLogo.vue'
+import AutopilotManagerUpdater from './AutopilotManagerUpdater.vue'
+import EndpointCard from './EndpointCard.vue'
+import CreationDialog from './EndpointCreationDialog.vue'
+
+const autopilot_manager_store: AutopilotManagerStore = getModule(AutopilotManagerStore)
+
+export default Vue.extend({
+  name: 'WifiManager',
+  components: {
+    EndpointCard,
+    SpinningLogo,
+    CreationDialog,
+    AutopilotManagerUpdater,
+  },
+  data() {
+    return {
+      show_creation_dialog: false,
+    }
+  },
+  computed: {
+    updating_endpoints(): boolean {
+      return autopilot_manager_store.updating_endpoints
+    },
+    available_endpoints(): AutopilotEndpoint[] {
+      return autopilot_manager_store.available_endpoints
+    },
+  },
+  methods: {
+    openCreationDialog(): void {
+      this.show_creation_dialog = true
+    },
+  },
+})
+</script>
+
+<style scoped>
+.endpoints-list {
+    max-width: 70%;
+    margin: auto;
+}
+</style>

--- a/core/frontend/src/components/autopilot/FirmwareManager.vue
+++ b/core/frontend/src/components/autopilot/FirmwareManager.vue
@@ -119,14 +119,14 @@ import axios, { AxiosRequestConfig } from 'axios'
 import Vue from 'vue'
 import { getModule } from 'vuex-module-decorators'
 
-import AutopilotStore from '@/store/autopilot'
+import AutopilotManagerStore from '@/store/autopilot_manager'
 import NotificationStore from '@/store/notifications'
 import { Firmware, Vehicle } from '@/types/autopilot'
-import { autopilot_service } from '@/types/frontend_services'
+import { autopilot_manager_service } from '@/types/frontend_services'
 import { LiveNotification, NotificationLevel } from '@/types/notifications'
 
 const notification_store: NotificationStore = getModule(NotificationStore)
-const autopilot_store: AutopilotStore = getModule(AutopilotStore)
+const autopilot_manager_store: AutopilotManagerStore = getModule(AutopilotManagerStore)
 
 enum InstallStatus {
   NotStarted,
@@ -213,7 +213,7 @@ export default Vue.extend({
       this.cloud_firmware_options_status = CloudFirmwareOptionsStatus.Fetching
       await axios({
         method: 'get',
-        url: `${autopilot_store.API_URL}/available_firmwares`,
+        url: `${autopilot_manager_store.API_URL}/available_firmwares`,
         timeout: 10000,
         params: { vehicle: this.chosen_vehicle },
       })
@@ -224,7 +224,7 @@ export default Vue.extend({
         .catch((error) => {
           notification_store.pushNotification(new LiveNotification(
             NotificationLevel.Error,
-            autopilot_service,
+            autopilot_manager_service,
             'FIRMWARE_FETCH_FAIL',
             `Could not fetch available firmwares: ${error.message}.`,
           ))
@@ -246,7 +246,7 @@ export default Vue.extend({
       if (this.upload_type === UploadType.Cloud) {
         // Populate request with data for cloud install
         Object.assign(axios_request_config, {
-          url: `${autopilot_store.API_URL}/install_firmware_from_url`,
+          url: `${autopilot_manager_store.API_URL}/install_firmware_from_url`,
           params: { url: this.chosen_firmware_url },
         })
       } else {
@@ -254,7 +254,7 @@ export default Vue.extend({
         if (!this.firmware_file) {
           notification_store.pushNotification(new LiveNotification(
             NotificationLevel.Warning,
-            autopilot_service,
+            autopilot_manager_service,
             'FILE_FIRMWARE_UPLOAD_FAIL',
             'Could not upload firmware: no firmware file selected.',
           ))
@@ -263,7 +263,7 @@ export default Vue.extend({
         const form_data = new FormData()
         form_data.append('binary', this.firmware_file)
         Object.assign(axios_request_config, {
-          url: `${autopilot_store.API_URL}/install_firmware_from_file`,
+          url: `${autopilot_manager_store.API_URL}/install_firmware_from_file`,
           headers: { 'Content-Type': 'multipart/form-data' },
           data: form_data,
         })
@@ -283,7 +283,7 @@ export default Vue.extend({
           }
           notification_store.pushNotification(new LiveNotification(
             NotificationLevel.Error,
-            autopilot_service,
+            autopilot_manager_service,
             'FILE_FIRMWARE_UPLOAD_FAIL',
             `Could not upload firmware: ${this.install_result_message}.`,
           ))

--- a/core/frontend/src/router/index.ts
+++ b/core/frontend/src/router/index.ts
@@ -1,6 +1,7 @@
 import Vue from 'vue'
 import VueRouter, { RouteConfig } from 'vue-router'
 
+import Endpoint from '../views/EndpointView.vue'
 import Firmware from '../views/FirmwareView.vue'
 import LogView from '../views/LogView.vue'
 import Main from '../views/MainView.vue'
@@ -22,6 +23,11 @@ const routes: Array<RouteConfig> = [
     path: '/logs',
     name: 'LogManager',
     component: LogView,
+  },
+  {
+    path: '/endpoints',
+    name: 'Endpoints',
+    component: Endpoint,
   },
 ]
 

--- a/core/frontend/src/store/autopilot_manager.ts
+++ b/core/frontend/src/store/autopilot_manager.ts
@@ -1,6 +1,7 @@
-import { Module, VuexModule } from 'vuex-module-decorators'
+import { Module, Mutation, VuexModule } from 'vuex-module-decorators'
 
 import store from '@/store'
+import { AutopilotEndpoint } from '@/types/autopilot'
 
 @Module({
   dynamic: true,
@@ -10,4 +11,19 @@ import store from '@/store'
 
 export default class AutopilotManagerStore extends VuexModule {
   API_URL = '/ardupilot-manager/v1.0'
+
+  available_endpoints: AutopilotEndpoint[] = []
+
+  updating_endpoints = true
+
+  @Mutation
+  setUpdatingEndpoints(updating: boolean): void {
+    this.updating_endpoints = updating
+  }
+
+  @Mutation
+  setAvailableEndpoints(available_endpoints: AutopilotEndpoint[]): void {
+    this.available_endpoints = available_endpoints
+    this.updating_endpoints = false
+  }
 }

--- a/core/frontend/src/store/autopilot_manager.ts
+++ b/core/frontend/src/store/autopilot_manager.ts
@@ -5,9 +5,9 @@ import store from '@/store'
 @Module({
   dynamic: true,
   store,
-  name: 'autopilot_store',
+  name: 'autopilot_manager_store',
 })
 
-export default class WifiStore extends VuexModule {
+export default class AutopilotManagerStore extends VuexModule {
   API_URL = '/ardupilot-manager/v1.0'
 }

--- a/core/frontend/src/types/autopilot.ts
+++ b/core/frontend/src/types/autopilot.ts
@@ -9,3 +9,31 @@ export enum Vehicle {
     Plane = 'Plane',
     Copter = 'Copter',
 }
+
+export enum EndpointType {
+    udpin = 'udpin',
+    udpout = 'udpout',
+    tcpin = 'tcpin',
+    tcpout = 'tcpout',
+    serial = 'serial',
+}
+
+export function userFriendlyEndpointType(type: EndpointType): string {
+  switch (type) {
+    case EndpointType.udpin: return 'UDP Server'
+    case EndpointType.udpout: return 'UDP Client'
+    case EndpointType.tcpin: return 'TCP Server'
+    case EndpointType.tcpout: return 'TCP Client'
+    case EndpointType.serial: return 'Serial'
+    default: return 'Undefined type'
+  }
+}
+export interface AutopilotEndpoint {
+    name: string
+    owner: string
+    connection_type: EndpointType
+    place: string
+    argument: number
+    persistent: boolean
+    protected: boolean
+}

--- a/core/frontend/src/types/frontend_services.ts
+++ b/core/frontend/src/types/frontend_services.ts
@@ -21,7 +21,7 @@ export const ethernet_service: Service = {
   version: '0.1.0',
 }
 
-export const autopilot_service: Service = {
+export const autopilot_manager_service: Service = {
   name: 'Autopilot Manager',
   description: 'Responsible for management of autopilot status and configuration.',
   company: 'Blue Robotics',

--- a/core/frontend/src/types/vuetify.ts
+++ b/core/frontend/src/types/vuetify.ts
@@ -1,0 +1,5 @@
+export type VForm = Vue & {
+    reset: () => void,
+    resetValidation: () => void,
+    validate: () => boolean,
+}

--- a/core/frontend/src/utils/pattern_validators.ts
+++ b/core/frontend/src/utils/pattern_validators.ts
@@ -1,0 +1,37 @@
+export function isSocketPort(port: number, public_range = true): boolean {
+  if (!Number.isInteger(port)) {
+    return false
+  }
+  if (port > 65535) {
+    return false
+  }
+  if (public_range) {
+    return port >= 1024
+  }
+  return port >= 0
+}
+
+export function isIntegerString(input: string): boolean {
+  return input.match(/^[0-9]+$/) != null
+}
+
+export function isBaudrate(baudrate: number): boolean {
+  const VALID_SERIAL_BAUDRATES = [
+    3000000, 2000000, 1000000, 921600, 570600, 460800, 257600, 250000, 230400, 115200, 57600, 38400, 19200, 9600,
+  ]
+  return VALID_SERIAL_BAUDRATES.includes(baudrate)
+}
+
+export function isIpAddress(ip: string): boolean {
+  const ip_pattern = /^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/
+  return ip_pattern.test(ip)
+}
+
+export function isFilepath(filepath: string): boolean {
+  const filepath_pattern = /^(.+)\/([^/]+)$/
+  return filepath_pattern.test(filepath)
+}
+
+export function isNotEmpty<T>(sizable: Array<T> | string | undefined | null): boolean {
+  return !!sizable && sizable.length > 0
+}

--- a/core/frontend/src/views/EndpointView.vue
+++ b/core/frontend/src/views/EndpointView.vue
@@ -1,0 +1,18 @@
+<template>
+  <v-container>
+    <endpoint-manager />
+  </v-container>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+
+import EndpointManager from '@/components/autopilot/EndpointManager.vue'
+
+export default Vue.extend({
+  name: 'EndpointView',
+  components: {
+    EndpointManager,
+  },
+})
+</script>


### PR DESCRIPTION
Add page for listing, creating and deleting autopilot endpoints.
Creation forms include IP/Path and Port/Baudrate validation.

Image soon on `rafaellehmkuhl/companion-core:endpoints-frontend`.

Partially solves #445 