### PR TITLE
core: ardupilot-manager: Remove tlog support for mavlink-router for now

### DIFF
--- a/core/services/ardupilot_manager/mavlink_proxy/MAVLinkRouter.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/MAVLinkRouter.py
@@ -57,13 +57,11 @@ class MAVLinkRouter(AbstractRouter):
         ]:
             raise ValueError(f"Master endpoint of type {master.connection_type} not supported on MavlinkRouter.")
 
-        log = f"--tlog {self.logdir().resolve()}"
-
         if master.connection_type == EndpointType.TCPServer:
             # The "--tcp-port 0" argument is used to prevent the router from binding TCP port 5760
-            return f"{self.binary()} --tcp-endpoint {master.place}:{master.argument} --tcp-port 0 {log} {endpoints}"
+            return f"{self.binary()} --tcp-endpoint {master.place}:{master.argument} --tcp-port 0 {endpoints}"
 
-        return f"{self.binary()} {master.place}:{master.argument} --tcp-port 0 {log} {endpoints}"
+        return f"{self.binary()} {master.place}:{master.argument} --tcp-port 0 {endpoints}"
 
     @staticmethod
     def name() -> str:


### PR DESCRIPTION
The support has some problems, we are going to disable until tlog works for multiple endpoints

Fix #475 