### PR TITLE
Add extras on autopilot API

### DIFF
--- a/core/services/ardupilot_manager/main.py
+++ b/core/services/ardupilot_manager/main.py
@@ -139,6 +139,16 @@ def set_platform(response: Response, use_sitl: bool, sitl_frame: SITLFrame = SIT
         return {"message": f"{error}"}
 
 
+@app.post("/restart", summary="Restart the autopilot with current set options.")
+@version(1, 0)
+def restart(response: Response) -> Any:
+    try:
+        autopilot.restart_ardupilot()
+    except Exception as error:
+        response.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
+        return {"message": f"{error}"}
+
+
 app = VersionedFastAPI(app, version="1.0.0", prefix_format="/v{major}.{minor}", enable_latest=True)
 app.mount("/", StaticFiles(directory=str(FRONTEND_FOLDER), html=True))
 

--- a/core/services/ardupilot_manager/main.py
+++ b/core/services/ardupilot_manager/main.py
@@ -113,6 +113,16 @@ def install_firmware_from_file(response: Response, binary: UploadFile = File(...
         autopilot.start_ardupilot()
 
 
+@app.get("/platform", response_model=Platform, summary="Check what is the current running platform.")
+@version(1, 0)
+def platform(response: Response) -> Any:
+    try:
+        return autopilot.current_platform
+    except Exception as error:
+        response.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
+        return {"message": f"{error}"}
+
+
 app = VersionedFastAPI(app, version="1.0.0", prefix_format="/v{major}.{minor}", enable_latest=True)
 app.mount("/", StaticFiles(directory=str(FRONTEND_FOLDER), html=True))
 


### PR DESCRIPTION
Contributes to #445 by allowing fetch of current running platform and system restart.

Also allows toggling between SITL and auto-detected board.