### PR TITLE
core: frontend: Use /version-chooser as view route

### DIFF
--- a/core/frontend/src/App.vue
+++ b/core/frontend/src/App.vue
@@ -160,7 +160,7 @@ export default Vue.extend({
           {
             title: 'Version-chooser',
             icon: 'mdi-cellphone-arrow-down',
-            route: '/versionchooser',
+            route: '/version-chooser',
           },
         ],
       },

--- a/core/frontend/src/router/index.ts
+++ b/core/frontend/src/router/index.ts
@@ -43,7 +43,7 @@ const routes: Array<RouteConfig> = [
     component: TerminalView,
   },
   {
-    path: '/versionchooser',
+    path: '/version-chooser',
     name: 'VersionChooser',
     component: VersionChooser,
   },


### PR DESCRIPTION
This is a "gambiarra", a "chuncho" to make the version-chooser service call the correct URL on API requests.