### PR TITLE
CI: Install appdirs and loguru before setup.py

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,8 @@ jobs:
         pip install pyfakefs pytest-cov pytest-timeout pylint mypy isort black asyncmock types-requests
         ## Install our own libraries
         ./core/libs/install-libs.sh
+        ## We need to install loguru and appdirs since they may be used inside setup.py
+        python -m pip install --user appdirs==1.4.4 loguru==0.5.3
         find . -type f -name "setup.py" | xargs --max-lines=1 --replace=% python % install --user
     -
       name: Run tests


### PR DESCRIPTION
these dependencies should be available before setup call

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>