### PR TITLE
core: wifi-manager: Add connection watchdog

### DIFF
--- a/core/services/wifi/typedefs.py
+++ b/core/services/wifi/typedefs.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import Optional
 
 from pydantic import BaseModel
@@ -21,3 +22,11 @@ class SavedWifiNetwork(BaseModel):
 class WifiCredentials(BaseModel):
     ssid: str
     password: str
+
+
+class ConnectionStatus(str, Enum):
+    JUST_DISCONNECTED = "JUST_DISCONNECTED"
+    STILL_DISCONNECTED = "STILL_DISCONNECTED"
+    JUST_CONNECTED = "JUST_CONNECTED"
+    STILL_CONNECTED = "STILL_CONNECTED"
+    UNKNOWN = "UNKNOWN"


### PR DESCRIPTION
Auto-enable and try reconnection to known networks if disconnected for more than specified time.

By removing the reenable of all saved networks on new connections, those changes also ensure connections are guaranteed (preventing impossibility of connecting to another network if there's a known one with bether signal nearby).

Solves #394 