### PR TITLE
Fix pixhawk retake

### DIFF
--- a/core/services/ardupilot_manager/mavlink_proxy/Manager.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/Manager.py
@@ -1,5 +1,5 @@
 import pathlib
-from typing import List, Set, Type
+from typing import Any, List, Set, Type
 
 # Plugins
 # pylint: disable=unused-import
@@ -80,3 +80,6 @@ class Manager:
 
     def set_logdir(self, log_dir: pathlib.Path) -> None:
         self.tool.set_logdir(log_dir)
+
+    def router_process(self) -> Any:
+        return self.tool.process()


### PR DESCRIPTION
Solves #523 for `mavlink-router`, our currently default (and only available) router.

`mavlink-router` process dies when the serial connection is lost, so we add a watchdog monitoring it's process.

To fix `mavproxy`'s behavior (we want?) I would change the package itself, or letting it die on serial lost (replicating `mavlink-router`'s behavior) or trying to retake connection (need to see if serial path is kept after recconection).

Image available soon.