### PR TITLE
core: docker: Do frontend copy after apt update/install for cache

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -1,9 +1,9 @@
 FROM node:current-buster-slim AS frontendBuilder
 
 # Build frontend
-COPY frontend /home/pi/frontend
 RUN apt update
 RUN apt install git -y
+COPY frontend /home/pi/frontend
 RUN cd /home/pi/frontend && yarn install --network-timeout=300000 && yarn build --skip-plugins @vue/cli-plugin-eslint
 
 # Download binaries


### PR DESCRIPTION
Since the frontend will be invalid cache hit, apt update and install will also run. The PR fix this issue.