### PR TITLE
core: frontend: Add menu prefix to view's URLs

### DIFF
--- a/core/frontend/src/App.vue
+++ b/core/frontend/src/App.vue
@@ -170,22 +170,22 @@ export default Vue.extend({
           {
             title: 'Firmware',
             icon: 'mdi-chip',
-            route: '/firmware',
+            route: '/autopilot/firmware',
           },
           {
             title: 'Log Browser',
             icon: 'mdi-file-multiple',
-            route: '/logs',
+            route: '/autopilot/logs',
           },
           {
             title: 'Endpoints',
             icon: 'mdi-arrow-decision',
-            route: '/endpoints',
+            route: '/autopilot/endpoints',
           },
           {
             title: 'Video',
             icon: 'mdi-video-vintage',
-            route: '/videomanager',
+            route: '/autopilot/videomanager',
           },
         ],
       },
@@ -196,17 +196,17 @@ export default Vue.extend({
           {
             title: 'Available Services',
             icon: 'mdi-account-hard-hat',
-            route: '/available-services',
+            route: '/tools/available-services',
           },
           {
             title: 'Bridges',
             icon: 'mdi-bridge',
-            route: '/bridges',
+            route: '/tools/bridges',
           },
           {
             title: 'Filebrowser',
             icon: 'mdi-file-tree',
-            route: '/filebrowser',
+            route: '/tools/filebrowser',
           },
           {
             title: 'NMEA Injector',
@@ -216,12 +216,12 @@ export default Vue.extend({
           {
             title: 'Terminal',
             icon: 'mdi-console',
-            route: '/web-terminal',
+            route: '/tools/web-terminal',
           },
           {
             title: 'Version-chooser',
             icon: 'mdi-cellphone-arrow-down',
-            route: '/version-chooser',
+            route: '/tools/version-chooser',
           },
         ],
       },

--- a/core/frontend/src/router/index.ts
+++ b/core/frontend/src/router/index.ts
@@ -23,7 +23,7 @@ const routes: Array<RouteConfig> = [
     component: Main,
   },
   {
-    path: '/firmware',
+    path: '/autopilot/firmware',
     name: 'Firmware',
     component: Firmware,
   },
@@ -33,37 +33,37 @@ const routes: Array<RouteConfig> = [
     component: GeneralAutopilot,
   },
   {
-    path: '/logs',
+    path: '/autopilot/logs',
     name: 'LogManager',
     component: LogView,
   },
   {
-    path: '/endpoints',
+    path: '/autopilot/endpoints',
     name: 'Endpoints',
     component: Endpoint,
   },
   {
-    path: '/filebrowser',
+    path: '/tools/filebrowser',
     name: 'FileBrowser',
     component: FileBrowserView,
   },
   {
-    path: '/web-terminal',
+    path: '/tools/web-terminal',
     name: 'Terminal',
     component: TerminalView,
   },
   {
-    path: '/version-chooser',
+    path: '/tools/version-chooser',
     name: 'VersionChooser',
     component: VersionChooser,
   },
   {
-    path: '/videomanager',
+    path: '/autopilot/videomanager',
     name: 'VideoManager',
     component: VideoManagerView,
   },
   {
-    path: '/bridges',
+    path: '/tools/bridges',
     name: 'Bridges',
     component: BridgesView,
   },
@@ -73,7 +73,7 @@ const routes: Array<RouteConfig> = [
     component: NMEAInjectorView,
   },
   {
-    path: '/available-services',
+    path: '/tools/available-services',
     name: 'Available Services',
     component: AvailableServicesView,
   },


### PR DESCRIPTION
Views under the autopilot menu received `/autopilot` as a prefix. Same happened for tools menu.

Image already available.