### PR TITLE
core: tools: nginx: Add 2770 redirect to companion.local

### DIFF
--- a/core/tools/nginx/nginx.conf
+++ b/core/tools/nginx/nginx.conf
@@ -29,6 +29,15 @@ http {
     access_log /var/log/nginx/access.log;
     error_log /var/log/nginx/error.log;
 
+    # Redirect legacy companion port (Companion 0.0.X) to our new homepage
+    server{
+        listen 2770;
+
+        location / {
+            rewrite ^/(.*)$ http://companion.local redirect;
+        }
+    }
+
     server {
         listen 80;
 


### PR DESCRIPTION
Fix #632 

Available on: patrickelectric/companion-core:redirect_nginx