### PR TITLE
core: tools: mavlink_camera_manager: Update to version t3.0.11

### DIFF
--- a/core/tools/mavlink_camera_manager/bootstrap.sh
+++ b/core/tools/mavlink_camera_manager/bootstrap.sh
@@ -5,7 +5,7 @@ set -e
 
 LOCAL_BINARY_PATH="/usr/bin/mavlink-camera-manager"
 
-VERSION=t3.0.9
+VERSION=t3.0.11
 
 # By default we install armv7
 REMOTE_BINARY_URL="https://github.com/patrickelectric/mavlink-camera-manager/releases/download/${VERSION}/mavlink-camera-manager-armv7"


### PR DESCRIPTION
- Provide correct video type over mavlink, RTPUDP over RTSP
- Add stats in V4L control to inform if it's disabled or inactive

Fix #649
Fix #494 

Available on: patrickelectric/companion-core:update_camera_manager