### PR TITLE
core: dockerfile: Use cache for node_modules

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -4,7 +4,8 @@ FROM node:16-buster-slim AS frontendBuilder
 ARG VUE_APP_GIT_DESCRIBE
 
 COPY frontend /home/pi/frontend
-RUN cd /home/pi/frontend && yarn install --network-timeout=300000 && yarn build --skip-plugins @vue/cli-plugin-eslint
+RUN --mount=type=cache,target=/home/pi/frontend/node_modules yarn --cwd /home/pi/frontend install --network-timeout=300000
+RUN --mount=type=cache,target=/home/pi/frontend/node_modules yarn --cwd /home/pi/frontend build --skip-plugins @vue/cli-plugin-eslint
 
 # Download binaries
 FROM bluerobotics/companion-base:v0.0.2 as downloadBinaries


### PR DESCRIPTION
This makes the install step to be cached and when used it takes only
10s to run, before this change it could take up almost 2min.

Helps with #437 