### PR TITLE
core: tools: bootstraps: Add missing 'set -e' to raise if any command fails

### DIFF
--- a/core/libs/install-libs.sh
+++ b/core/libs/install-libs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Immediately exist on errors
+# Immediately exit on errors
 set -e
 
 CURRENT_PATH=$(dirname "$0")

--- a/core/services/install-services.sh
+++ b/core/services/install-services.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Immediately exist on errors
+# Immediately exit on errors
 set -e
 
 BUILD_PACKAGES=(

--- a/core/tools/ardupilot_tools/bootstrap.sh
+++ b/core/tools/ardupilot_tools/bootstrap.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Immediately exit on errors
+set -e
+
 ## Download and install necessary tools to user binary folder with the correct permissions
 
 ### Ardupilot's uploader is used to upload firmwares to serial boards

--- a/core/tools/ardupilot_tools/bootstrap.sh
+++ b/core/tools/ardupilot_tools/bootstrap.sh
@@ -9,8 +9,13 @@ set -e
 COMMIT_HASH=4ea8c32c61781fa36dff9748fe3a18cdb5743abb
 LOCAL_PATH_UPLOADER="/usr/bin/ardupilot_fw_uploader.py"
 REMOTE_URL_UPLOADER="https://raw.githubusercontent.com/ArduPilot/ardupilot/${COMMIT_HASH}/Tools/scripts/uploader.py"
-wget "$REMOTE_URL_UPLOADER" -O "$LOCAL_PATH_UPLOADER"
-chmod +x "$LOCAL_PATH_UPLOADER"
+
+# Sudo command is not available on docker and the script is also used in different environments
+# The SUDO alias allow the usage of sudo when such command exists and also ignore if it doesn't
+SUDO="$(command -v sudo || echo '')"
+readonly SUDO
+$SUDO wget "$REMOTE_URL_UPLOADER" -O "$LOCAL_PATH_UPLOADER"
+$SUDO chmod +x "$LOCAL_PATH_UPLOADER"
 
 ## Download and install necessary modules to user-site folder
 

--- a/core/tools/filebrowser/bootstrap.sh
+++ b/core/tools/filebrowser/bootstrap.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Immediately exit on errors
+set -e
+
 LOCAL_BINARY_PATH="/usr/bin/filebrowser"
 VERSION=v2.15.0
 

--- a/core/tools/logviewer/bootstrap.sh
+++ b/core/tools/logviewer/bootstrap.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Immediately exit on errors
+set -e
+
 DESTINATION_PATH="/home/pi/tools/logviewer"
 
 VERSION=v0.9.2

--- a/core/tools/mavlink2rest/bootstrap.sh
+++ b/core/tools/mavlink2rest/bootstrap.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Immediately exit on errors
+set -e
+
 LOCAL_BINARY_PATH="/usr/bin/mavlink2rest"
 
 VERSION=t0.11.6

--- a/core/tools/ttyd/bootstrap.sh
+++ b/core/tools/ttyd/bootstrap.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Immediately exit on errors
+set -e
+
 LOCAL_BINARY_PATH="/usr/bin/ttyd"
 VERSION=1.6.3
 


### PR DESCRIPTION
I got a situation where ttyd fails to download but the ttyd file is there and empty 