### PR TITLE
Improve wifi-manager frontend

### DIFF
--- a/core/frontend/src/components/wifi/ConnectionDialog.vue
+++ b/core/frontend/src/components/wifi/ConnectionDialog.vue
@@ -196,6 +196,15 @@ export default Vue.extend({
       }
     },
   },
+  watch: {
+    show(val: boolean): void {
+      if (val === false) {
+        this.connection_status = ConnectionStatus.NotStarted
+        this.connection_result_message = ''
+        this.password = ''
+        this.force_password = false
+      }
+    },
   },
   methods: {
     toggleInfoShow(): void {

--- a/core/frontend/src/components/wifi/ConnectionDialog.vue
+++ b/core/frontend/src/components/wifi/ConnectionDialog.vue
@@ -238,7 +238,6 @@ export default Vue.extend({
         })
         .finally(() => {
           this.password = ''
-          this.showDialog(false)
         })
     },
     async removeSavedWifiNetwork(): Promise<void> {

--- a/core/frontend/src/components/wifi/ConnectionDialog.vue
+++ b/core/frontend/src/components/wifi/ConnectionDialog.vue
@@ -167,7 +167,7 @@ export default Vue.extend({
       await back_axios({
         method: 'post',
         url: `${wifi.API_URL}/connect`,
-        timeout: 2000,
+        timeout: 20000,
         data: credentials,
         params: { hidden: this.is_hidden },
       })

--- a/core/frontend/src/components/wifi/ConnectionDialog.vue
+++ b/core/frontend/src/components/wifi/ConnectionDialog.vue
@@ -231,7 +231,8 @@ export default Vue.extend({
         })
         .catch((error) => {
           this.connection_status = ConnectionStatus.Failed
-          const message = `Could not connect to wifi network: ${error.message}.`
+          let message = error.response.data.detail ? error.response.data.detail : `Connection failed: ${error}`
+          message = message.concat('\n', 'Please check if the password is correct.')
           this.connection_result_message = message
           notifications.pushError({ service: wifi_service, type: 'WIFI_CONNECT_FAIL', message })
         })
@@ -248,7 +249,7 @@ export default Vue.extend({
         params: { ssid: this.network.ssid },
       })
         .catch((error) => {
-          const message = `Could not remove saved wifi network: ${error.message}.`
+          const message = error.response.data.detail ? error.response.data.detail : `Connection failed: ${error}`
           notifications.pushError({ service: wifi_service, type: 'WIFI_FORGET_FAIL', message })
         })
         .finally(() => {

--- a/core/frontend/src/components/wifi/ConnectionDialog.vue
+++ b/core/frontend/src/components/wifi/ConnectionDialog.vue
@@ -1,6 +1,6 @@
 <template>
   <v-dialog
-    width="300"
+    width="350"
     :value="show"
     @input="showDialog"
   >

--- a/core/frontend/src/components/wifi/ConnectionDialog.vue
+++ b/core/frontend/src/components/wifi/ConnectionDialog.vue
@@ -228,6 +228,8 @@ export default Vue.extend({
           this.connection_status = ConnectionStatus.Succeeded
           this.connection_result_message = `Successfully connected to '${this.real_ssid}'`
           wifi.setNetworkStatus(null)
+          this.password = ''
+          this.force_password = false
         })
         .catch((error) => {
           this.connection_status = ConnectionStatus.Failed
@@ -235,9 +237,6 @@ export default Vue.extend({
           message = message.concat('\n', 'Please check if the password is correct.')
           this.connection_result_message = message
           notifications.pushError({ service: wifi_service, type: 'WIFI_CONNECT_FAIL', message })
-        })
-        .finally(() => {
-          this.password = ''
         })
     },
     async removeSavedWifiNetwork(): Promise<void> {

--- a/core/frontend/src/components/wifi/DisconnectionDialog.vue
+++ b/core/frontend/src/components/wifi/DisconnectionDialog.vue
@@ -104,6 +104,7 @@ export default Vue.extend({
       this.show_more_info = !this.show_more_info
     },
     async disconnectFromWifiNetwork(): Promise<void> {
+      this.showDialog(false)
       await back_axios({
         method: 'get',
         url: `${wifi.API_URL}/disconnect`,
@@ -116,9 +117,6 @@ export default Vue.extend({
         .catch((error) => {
           const message = `Could not disconnect from wifi network: ${error.message}.`
           notifications.pushError({ service: wifi_service, type: 'WIFI_DISCONNECT_FAIL', message })
-        })
-        .finally(() => {
-          this.showDialog(false)
         })
     },
     showDialog(state: boolean): void {


### PR DESCRIPTION
This PR aims to improve (a lot) user's experience with wifi connection. Between the changes are:
- Add loading status while connecting
- Add connection result messages
- Raise wifi connection timeout, preventing cancelled requests
- Fix disconnection dialog appearing unexpectedly
- Reset password input box after connection
- Use backend's detailed error messages on connection

![image](https://user-images.githubusercontent.com/6551040/142669174-67e798e4-cd3f-4418-a595-2f61c711982b.png)
![image](https://user-images.githubusercontent.com/6551040/142669185-ec5b3bbf-0279-40d1-8862-935fd384766e.png)
![image](https://user-images.githubusercontent.com/6551040/142669227-c517899b-76c1-4da2-b808-db880ddad72a.png)


Needs #674

Fix #513
Fix #533 

Image available already.