### PR TITLE
core: frontend: Start all periodicall resquests together

### DIFF
--- a/core/frontend/src/components/app/BackendStatusChecker.vue
+++ b/core/frontend/src/components/app/BackendStatusChecker.vue
@@ -20,8 +20,8 @@ export default Vue.extend({
       return this.backend_offline ? 'Disconnected' : ''
     },
   },
-  async mounted() {
-    await callPeriodically(this.checkBackendStatus, 3000)
+  mounted() {
+    callPeriodically(this.checkBackendStatus, 3000)
   },
   methods: {
     async checkBackendStatus(): Promise<void> {

--- a/core/frontend/src/components/autopilot/AutopilotManagerUpdater.vue
+++ b/core/frontend/src/components/autopilot/AutopilotManagerUpdater.vue
@@ -21,9 +21,9 @@ import { callPeriodically } from '@/utils/helper_functions'
 
 export default Vue.extend({
   name: 'AutopilotManagerUpdater',
-  async mounted() {
-    await callPeriodically(this.fetchAvailableEndpoints, 5000)
-    await callPeriodically(this.fetchCurrentPlatform, 5000)
+  mounted() {
+    callPeriodically(this.fetchAvailableEndpoints, 5000)
+    callPeriodically(this.fetchCurrentPlatform, 5000)
   },
   methods: {
     async fetchAvailableEndpoints(): Promise<void> {

--- a/core/frontend/src/components/bridges/BridgetUpdater.vue
+++ b/core/frontend/src/components/bridges/BridgetUpdater.vue
@@ -20,9 +20,9 @@ import { callPeriodically } from '@/utils/helper_functions'
 
 export default Vue.extend({
   name: 'BridgetUpdater',
-  async mounted() {
-    await callPeriodically(this.fetchAvailableBridges, 5000)
-    await callPeriodically(this.fetchAvailableSerialPorts, 5000)
+  mounted() {
+    callPeriodically(this.fetchAvailableBridges, 5000)
+    callPeriodically(this.fetchAvailableSerialPorts, 5000)
   },
   methods: {
     async fetchAvailableBridges(): Promise<void> {

--- a/core/frontend/src/components/ethernet/EthernetUpdater.vue
+++ b/core/frontend/src/components/ethernet/EthernetUpdater.vue
@@ -13,8 +13,8 @@ import { callPeriodically } from '@/utils/helper_functions'
 
 export default Vue.extend({
   name: 'EthernetUpdater',
-  async mounted() {
-    await callPeriodically(this.fetchAvailableInterfaces, 5000)
+  mounted() {
+    callPeriodically(this.fetchAvailableInterfaces, 5000)
   },
   methods: {
     async fetchAvailableInterfaces(): Promise<void> {

--- a/core/frontend/src/components/nmea-injector/NMEAInjectorUpdater.vue
+++ b/core/frontend/src/components/nmea-injector/NMEAInjectorUpdater.vue
@@ -20,8 +20,8 @@ import { callPeriodically } from '@/utils/helper_functions'
 
 export default Vue.extend({
   name: 'NMEAInjectorUpdater',
-  async mounted() {
-    await callPeriodically(this.fetchAvailableNMEASockets, 5000)
+  mounted() {
+    callPeriodically(this.fetchAvailableNMEASockets, 5000)
   },
   methods: {
     async fetchAvailableNMEASockets(): Promise<void> {

--- a/core/frontend/src/components/video-manager/VideoUpdater.vue
+++ b/core/frontend/src/components/video-manager/VideoUpdater.vue
@@ -13,9 +13,9 @@ import { callPeriodically } from '@/utils/helper_functions'
 
 export default Vue.extend({
   name: 'VideoUpdater',
-  async mounted() {
-    await callPeriodically(video.fetchDevices, 5000)
-    await callPeriodically(video.fetchStreams, 5000)
+  mounted() {
+    callPeriodically(video.fetchDevices, 5000)
+    callPeriodically(video.fetchStreams, 5000)
   },
 })
 </script>

--- a/core/frontend/src/components/wifi/WifiUpdater.vue
+++ b/core/frontend/src/components/wifi/WifiUpdater.vue
@@ -14,10 +14,10 @@ import { callPeriodically } from '@/utils/helper_functions'
 
 export default Vue.extend({
   name: 'WifiUpdater',
-  async mounted() {
-    await callPeriodically(this.fetchSavedNetworks, 5000)
-    await callPeriodically(this.fetchNetworkStatus, 5000)
-    await callPeriodically(this.fetchAvailableNetworks, 10000)
+  mounted() {
+    callPeriodically(this.fetchSavedNetworks, 5000)
+    callPeriodically(this.fetchNetworkStatus, 5000)
+    callPeriodically(this.fetchAvailableNetworks, 10000)
   },
   methods: {
     async fetchNetworkStatus(): Promise<void> {


### PR DESCRIPTION
With previous approach, each request would wait for the previous one to be fullfiled before starting.

This was the cause of, among other things, wifi scans and video-stream fetchs taking about 5-10 seconds to start on page refresh.

Fix #582 