### PR TITLE
core: frontend: Only show strongest access point when multiple with the same SSID

### DIFF
--- a/core/frontend/src/components/wifi/WifiManager.vue
+++ b/core/frontend/src/components/wifi/WifiManager.vue
@@ -54,6 +54,7 @@
 </template>
 
 <script lang="ts">
+import { uniqBy } from 'lodash'
 import Vue from 'vue'
 
 import wifi from '@/store/wifi'
@@ -87,7 +88,7 @@ export default Vue.extend({
       return wifi.current_network
     },
     connectable_networks(): Network[] | null {
-      return wifi.connectable_networks
+      return uniqBy(wifi.connectable_networks, 'ssid')
     },
   },
   methods: {


### PR DESCRIPTION
Like most wifi managers this PR makes ours only show the access-point with the strongest signal-level. Connecting to one AP or another becomes a responsability `wpa` itself.

If we see the necessity in the future we can add a logic to store both the ssid and the bssid and try enforcing the connection to the desired AP (the one with the desired bssid). As this would make everything less intuitive to the user, we should discuss that with care.

Fix #664 