### PR TITLE
core: Support disabling mavlink endpoints

### DIFF
--- a/core/frontend/src/components/autopilot/EndpointCard.vue
+++ b/core/frontend/src/components/autopilot/EndpointCard.vue
@@ -51,15 +51,13 @@
             <v-card class="elevation-0 d-flex flex-column align-center pa-0">
               <v-icon
                 class="ma-1"
-                :disabled="!endpoint.persistent"
               >
-                mdi-content-save
+                {{ persistent_icon }}
               </v-icon>
               <v-icon
                 class="ma-1"
-                :disabled="!endpoint.protected"
               >
-                mdi-lock
+                {{ protected_icon }}
               </v-icon>
             </v-card>
           </v-col>
@@ -105,6 +103,14 @@ export default Vue.extend({
     return {
       userFriendlyEndpointType,
     }
+  },
+  computed: {
+    persistent_icon(): string {
+      return this.endpoint.persistent ? 'mdi-content-save' : 'mdi-content-save-off'
+    },
+    protected_icon(): string {
+      return this.endpoint.protected ? 'mdi-lock' : 'mdi-lock-off'
+    },
   },
   methods: {
     async removeEndpoint(): Promise<void> {

--- a/core/frontend/src/components/autopilot/EndpointCard.vue
+++ b/core/frontend/src/components/autopilot/EndpointCard.vue
@@ -59,6 +59,11 @@
               >
                 {{ protected_icon }}
               </v-icon>
+              <v-icon
+                class="ma-1"
+              >
+                {{ enabled_icon }}
+              </v-icon>
             </v-card>
           </v-col>
         </v-row>
@@ -110,6 +115,9 @@ export default Vue.extend({
     },
     protected_icon(): string {
       return this.endpoint.protected ? 'mdi-lock' : 'mdi-lock-off'
+    },
+    enabled_icon(): string {
+      return this.endpoint.enabled ? 'mdi-lightbulb-on' : 'mdi-lightbulb-off'
     },
   },
   methods: {

--- a/core/frontend/src/components/autopilot/EndpointCreationDialog.vue
+++ b/core/frontend/src/components/autopilot/EndpointCreationDialog.vue
@@ -59,6 +59,11 @@
             disabled
           />
 
+          <v-checkbox
+            v-model="endpoint.enabled"
+            label="Start endpoint already enabled?"
+          />
+
           <v-btn
             color="success"
             class="mr-4"
@@ -108,6 +113,7 @@ export default Vue.extend({
         argument: '',
         protected: false,
         persistent: false,
+        enabled: true,
       },
     }
   },

--- a/core/frontend/src/types/autopilot.ts
+++ b/core/frontend/src/types/autopilot.ts
@@ -44,4 +44,5 @@ export interface AutopilotEndpoint {
     argument: number
     persistent: boolean
     protected: boolean
+    enabled: boolean
 }

--- a/core/services/ardupilot_manager/ArduPilotManager.py
+++ b/core/services/ardupilot_manager/ArduPilotManager.py
@@ -224,12 +224,23 @@ class ArduPilotManager(metaclass=Singleton):
             self.add_new_endpoints(
                 {
                     Endpoint(
-                        "GCS Link",
+                        "GCS Server Link",
                         self.settings.app_name,
                         EndpointType.UDPServer,
                         "0.0.0.0",
                         14550,
-                        protected=True,
+                    )
+                }
+            )
+            self.add_new_endpoints(
+                {
+                    Endpoint(
+                        "GCS Client Link",
+                        self.settings.app_name,
+                        EndpointType.UDPClient,
+                        "192.168.2.1",
+                        14550,
+                        enabled=False,
                     )
                 }
             )

--- a/core/services/ardupilot_manager/exceptions.py
+++ b/core/services/ardupilot_manager/exceptions.py
@@ -69,3 +69,7 @@ class EndpointCreationFail(RuntimeError):
 
 class EndpointDeleteFail(RuntimeError):
     """Failed to delete endpoint."""
+
+
+class EndpointUpdateFail(RuntimeError):
+    """Failed to update endpoint."""

--- a/core/services/ardupilot_manager/main.py
+++ b/core/services/ardupilot_manager/main.py
@@ -69,6 +69,17 @@ def remove_endpoints(response: Response, endpoints: Set[Endpoint] = Body(...)) -
         return {"message": f"{error}"}
 
 
+@app.put("/endpoints", status_code=status.HTTP_200_OK)
+@version(1, 0)
+def update_endpoints(response: Response, endpoints: Set[Endpoint] = Body(...)) -> Any:
+    try:
+        autopilot.update_endpoints(endpoints)
+        autopilot.reload_endpoints()
+    except Exception as error:
+        response.status_code = status.HTTP_400_BAD_REQUEST
+        return {"message": f"{error}"}
+
+
 @app.get(
     "/available_firmwares",
     response_model=List[Firmware],

--- a/core/services/ardupilot_manager/mavlink_proxy/Endpoint.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/Endpoint.py
@@ -8,6 +8,7 @@ from typedefs import EndpointType
 
 
 @dataclass
+# pylint: disable=too-many-instance-attributes
 class Endpoint:
     name: constr(strip_whitespace=True, min_length=3, max_length=50)  # type: ignore
     owner: constr(strip_whitespace=True, min_length=3, max_length=50)  # type: ignore
@@ -18,6 +19,7 @@ class Endpoint:
 
     persistent: Optional[bool] = False
     protected: Optional[bool] = False
+    enabled: Optional[bool] = True
 
     @root_validator
     @classmethod

--- a/core/services/ardupilot_manager/mavlink_proxy/Endpoint.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/Endpoint.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Type
+from typing import Any, Dict, Iterable, Optional, Type
 
 import validators
 from pydantic import constr, root_validator
@@ -48,6 +48,10 @@ class Endpoint:
         raise ValueError(
             f"Invalid connection_type: {connection_type}. Valid types are: {[e.value for e in EndpointType]}."
         )
+
+    @staticmethod
+    def filter_enabled(endpoints: Iterable["Endpoint"]) -> Iterable["Endpoint"]:
+        return [endpoint for endpoint in endpoints if endpoint.enabled is True]
 
     def __str__(self) -> str:
         return ":".join([self.connection_type, self.place, str(self.argument)])

--- a/core/services/ardupilot_manager/mavlink_proxy/MAVLinkRouter.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/MAVLinkRouter.py
@@ -49,7 +49,8 @@ class MAVLinkRouter(AbstractRouter):
         sorted_endpoints = sorted(
             self.endpoints(), key=lambda endpoint: types_order[endpoint.connection_type]  # type: ignore
         )
-        endpoints = " ".join([convert_endpoint(endpoint) for endpoint in sorted_endpoints])
+        filtered_endpoints = Endpoint.filter_enabled(sorted_endpoints)
+        endpoints = " ".join([convert_endpoint(endpoint) for endpoint in filtered_endpoints])
 
         if master.connection_type not in [
             EndpointType.UDPServer,

--- a/core/services/ardupilot_manager/mavlink_proxy/MAVProxy.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/MAVProxy.py
@@ -30,7 +30,8 @@ class MAVProxy(AbstractRouter):
                 return f"--out={str(endpoint)}"
             return f"--out={serial_endpoint_as_input(endpoint)}"
 
-        endpoints = " ".join([convert_endpoint(endpoint) for endpoint in self.endpoints()])
+        filtered_endpoints = Endpoint.filter_enabled(self.endpoints())
+        endpoints = " ".join([convert_endpoint(endpoint) for endpoint in filtered_endpoints])
 
         master_string = str(master)
         if master.connection_type == EndpointType.Serial:

--- a/core/services/ardupilot_manager/mavlink_proxy/test_all.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/test_all.py
@@ -57,6 +57,7 @@ def test_endpoint() -> None:
         "argument": 14550,
         "persistent": False,
         "protected": False,
+        "enabled": True,
     }, "Endpoint dict does not match."
 
 


### PR DESCRIPTION
- Add 'enabled' property to mavlink endpoints, so they can be disabled (not used by the mavlink router) without being deleted
- Allow users to enable/disable endpoints on the fly with the endpoint frontend

With this change, the default GCS Link was duplicated, so we have a server one and a client one (with the former pointing to 192.168.2.1). The client endpoint is disabled by default. This change will make the life of our clients experiencing connection problems easier.

Fix #657 