### PR TITLE
Minor updates to install scripts

### DIFF
--- a/install/boards/bcm_27xx.sh
+++ b/install/boards/bcm_27xx.sh
@@ -68,7 +68,7 @@ sudo sed -e 's/console=serial[0-9],[0-9]*\ //' -i /boot/cmdline.txt
 # Update raspberry pi firmware
 # this is required to avoid 'i2c transfer timed out' kernel errors
 # on older firmware versions
-if grep -q ID=raspbian < /etc/os-release; then
+if grep -q VERSION_CODENAME=buster < /etc/os-release; then
     RPI_FIRMWARE_VERSION=1340be4
     if sudo JUST_CHECK=1 rpi-update $RPI_FIRMWARE_VERSION | grep "Firmware update required"; then
         echo "- Run rpi update."

--- a/install/boards/bcm_27xx.sh
+++ b/install/boards/bcm_27xx.sh
@@ -34,9 +34,9 @@ for STRING in \
     "dtoverlay=uart4" \
     "dtoverlay=uart5" \
     "dtparam=i2c_vc=on" \
-    "dtoverlay=i2c1" \
-    "dtoverlay=i2c4,pins_6_7" \
-    "dtoverlay=i2c6,pins_22_23" \
+    "dtoverlay=i2c1,baudrate=1000000" \
+    "dtoverlay=i2c4,pins_6_7,baudrate=1000000" \
+    "dtoverlay=i2c6,pins_22_23,baudrate=400000" \
     "dtparam=spi=on" \
     "dtoverlay=spi0-led" \
     "dtoverlay=spi1-3cs" \

--- a/install/install.sh
+++ b/install/install.sh
@@ -12,6 +12,7 @@ set -e
 SUPPORTED_ARCHITECTURES=(
   "armhf" # Pi, Pi2, Pi3, Pi4
   "armv7" # Pi2, Pi3, Pi4
+  "armv7l" # Pi2, Pi3, Pi4 (Raspberry Pi OS Bullseye)
   "aarch64" # Pi3, Pi4
 )
 ARCHITECTURE="$(uname -m)"


### PR DESCRIPTION
Fix #697 

Also sets the baudrates for the i2c buses for navigator. 1MHz for the internal buses and 400kHz for external peripherals.