### PR TITLE
Core: Ping: fix logging of random SysFS objects

### DIFF
--- a/core/services/ping/portwatcher.py
+++ b/core/services/ping/portwatcher.py
@@ -55,7 +55,8 @@ class PortWatcher:
         # TODO: try https://pypi.org/project/inotify/
         while True:
             ports = serial.tools.list_ports.comports()
-            logging.debug(f"Currently detected ports: {ports}")
+            ports_description = [f"{port.subsystem}:{port.name}" for port in ports]
+            logging.debug(f"Currently detected ports: {ports_description}")
             found_ports = set()
             for port in ports:
                 if self.port_should_be_probed(port):


### PR DESCRIPTION
Fix #692

We can also print other information, or just remove this line completely.
I think it is useful for debugging, as we know exactly what ports the serial lib is finding (so that we can easily detect a broken serial adapter).

portwatcher:start_watching:59 - Currently detected ports: ['usb-serial:ttyUSB1', 'usb-serial:ttyUSB0', 'amba:ttyAMA3', 'amba:ttyAMA2', 'amba:ttyAMA1', 'amba:ttyAMA0']