### PR TITLE
ardupilot-manager: change default endpoint for the GCS to the 'legacy' 192.168.2.1

### DIFF
--- a/core/services/ardupilot_manager/ArduPilotManager.py
+++ b/core/services/ardupilot_manager/ArduPilotManager.py
@@ -235,6 +235,7 @@ class ArduPilotManager(metaclass=Singleton):
                 "0.0.0.0",
                 14550,
                 persistent=True,
+                enabled=False,
             ),
             Endpoint(
                 "GCS Client Link",
@@ -243,7 +244,7 @@ class ArduPilotManager(metaclass=Singleton):
                 "192.168.2.1",
                 14550,
                 persistent=True,
-                enabled=False,
+                enabled=True,
             ),
             Endpoint(
                 "MAVLink2Rest",


### PR DESCRIPTION
this will make the life of tester at the office and new users easier