### PR TITLE
Add pirate mode and allow starting/stopping autopilot

### DIFF
--- a/core/frontend/src/App.vue
+++ b/core/frontend/src/App.vue
@@ -13,6 +13,25 @@
         />
 
         <v-spacer />
+        <div 
+          v-if="settings.is_pirate_mode"
+        >
+          Ahoy matey! You're running
+          <v-icon>
+            mdi-flag-variant
+          </v-icon>
+          <v-icon>
+            mdi-skull-crossbones
+          </v-icon>
+          Pirate Mode
+          <v-icon>
+            mdi-skull-crossbones
+          </v-icon>
+          <v-icon>
+            mdi-flag-variant
+          </v-icon>
+        </div>
+
         <backend-status-checker @statusChange="changeBackendStatus" />
         <v-spacer />
         <health-tray-menu />
@@ -114,6 +133,8 @@
 <script lang="ts">
 import Vue from 'vue'
 
+import settings from '@/libs/settings'
+
 import BackendStatusChecker from './components/app/BackendStatusChecker.vue'
 import PowerMenu from './components/app/PowerMenu.vue'
 import SettingsMenu from './components/app/SettingsMenu.vue'
@@ -150,6 +171,7 @@ export default Vue.extend({
   },
 
   data: () => ({
+    settings,
     drawer: false,
     backend_offline: false,
     menus: [

--- a/core/frontend/src/components/app/SettingsMenu.vue
+++ b/core/frontend/src/components/app/SettingsMenu.vue
@@ -23,24 +23,20 @@
 
         <v-divider />
 
-        <v-container class="pa-8">
-          <v-row
-            justify="center"
+        <v-card-actions class="d-flex flex-column justify-space-around align-center">
+          <v-btn
+            @click="reset_settings"
           >
-            <v-btn
-              @click="reset_settings"
-            >
-              <v-icon left>
-                mdi-trash-can
-              </v-icon>
-              Reset Settings
-            </v-btn>
-            <v-switch
-              v-model="settings.is_dark_theme"
-              label="Dark mode"
-            />
-          </v-row>
-        </v-container>
+            <v-icon left>
+              mdi-trash-can
+            </v-icon>
+            Reset Settings
+          </v-btn>
+          <v-switch
+            v-model="settings.is_dark_theme"
+            label="Dark mode"
+          />
+        </v-card-actions>
       </v-card>
     </v-dialog>
     <v-dialog

--- a/core/frontend/src/components/app/SettingsMenu.vue
+++ b/core/frontend/src/components/app/SettingsMenu.vue
@@ -33,6 +33,11 @@
             Reset Settings
           </v-btn>
           <v-switch
+            v-model="settings.is_pirate_mode"
+            label="Pirate mode"
+            @change="togglePirateWarning"
+          />
+          <v-switch
             v-model="settings.is_dark_theme"
             label="Dark mode"
           />
@@ -48,6 +53,19 @@
         <v-container class="pa-8">
           Restart the system to finish the settings reset.
         </v-container>
+      </v-card>
+    </v-dialog>
+    <v-dialog
+      v-model="pirate_warning"
+      max-width="290"
+    >
+      <v-card>
+        <v-card-title class="text-h5">
+          Pirate mode activated!
+        </v-card-title>
+        <v-card-text>
+          With a shiny hook comes great responsibilities! If you're navigating, don't drink rum.
+        </v-card-text>
       </v-card>
     </v-dialog>
   </v-container>
@@ -72,9 +90,13 @@ export default Vue.extend({
       show_dialog: false,
       show_reset_dialog: false,
       settings,
+      pirate_warning: false,
     }
   },
   methods: {
+    togglePirateWarning(): void {
+      this.pirate_warning = settings.is_pirate_mode
+    },
     async reset_settings(): Promise<void> {
       await back_axios({
         url: `${API_URL}/settings/reset`,

--- a/core/frontend/src/libs/settings.ts
+++ b/core/frontend/src/libs/settings.ts
@@ -12,6 +12,16 @@ class Settings {
   set is_dark_theme(value: boolean) {
     settingsStore.setDarkTheme(value)
   }
+
+  // eslint-disable-next-line
+  get is_pirate_mode(): boolean {
+    return settingsStore.is_pirate_mode
+  }
+
+  // eslint-disable-next-line
+  set is_pirate_mode(value: boolean) {
+    settingsStore.setPirateMode(value)
+  }
 }
 
 const settings = new Settings()

--- a/core/frontend/src/store/settings.ts
+++ b/core/frontend/src/store/settings.ts
@@ -17,9 +17,17 @@ class SettingsStore extends VuexModule {
 
     is_dark_theme: boolean = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
 
+    is_pirate_mode = false
+
     @Mutation
     setDarkTheme(value: boolean): void {
       this.is_dark_theme = value
+      SettingsStore.save()
+    }
+
+    @Mutation
+    setPirateMode(value: boolean): void {
+      this.is_pirate_mode = value
       SettingsStore.save()
     }
 
@@ -86,7 +94,7 @@ class SettingsStore extends VuexModule {
 
       SettingsStore.load()
     }
-  }
+}
 
 export { SettingsStore }
 

--- a/core/services/ardupilot_manager/main.py
+++ b/core/services/ardupilot_manager/main.py
@@ -168,6 +168,30 @@ async def restart(response: Response) -> Any:
         return {"message": f"{error}"}
 
 
+@app.post("/start", summary="Start the autopilot.")
+@version(1, 0)
+async def start(response: Response) -> Any:
+    try:
+        logger.debug("Starting ardupilot...")
+        await autopilot.start_ardupilot()
+        logger.debug("Ardupilot successfully started.")
+    except Exception as error:
+        response.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
+        return {"message": f"{error}"}
+
+
+@app.post("/stop", summary="Stop the autopilot.")
+@version(1, 0)
+async def stop(response: Response) -> Any:
+    try:
+        logger.debug("Stopping ardupilot...")
+        await autopilot.kill_ardupilot()
+        logger.debug("Ardupilot successfully stopped.")
+    except Exception as error:
+        response.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
+        return {"message": f"{error}"}
+
+
 @app.post("/restore_default_firmware", summary="Restore default firmware.")
 @version(1, 0)
 async def restore_default_firmware(response: Response) -> Any:


### PR DESCRIPTION
- Add Pirate Mode (advanced/unsecure options available)
- Allows start and stop of the autopilot from the frontend, only when in Pirate Mode ‍ 

Fix #714 