### PR TITLE
core: frontend: Make UsbBusType consistent with `camera-manager` 3.1.0

### DIFF
--- a/core/frontend/src/types/video.ts
+++ b/core/frontend/src/types/video.ts
@@ -107,14 +107,8 @@ export interface CreatedStream {
   stream_information: StreamInformation
 }
 
-export interface UsbBus {
-  interface: string
-  usb_hub: number
-  usb_port: number
-}
-
 export interface UsbBusType {
-  Usb: UsbBus
+  Usb: string
 }
 
 export interface IspType {


### PR DESCRIPTION
To be merged after #724 