### PR TITLE
Use a shared mavlink-router endpoint for internal services

### DIFF
--- a/core/services/ardupilot_manager/ArduPilotManager.py
+++ b/core/services/ardupilot_manager/ArduPilotManager.py
@@ -247,15 +247,6 @@ class ArduPilotManager(metaclass=Singleton):
                 enabled=True,
             ),
             Endpoint(
-                "MAVLink2Rest",
-                self.settings.app_name,
-                EndpointType.UDPClient,
-                "127.0.0.1",
-                14000,
-                persistent=True,
-                protected=True,
-            ),
-            Endpoint(
                 "Internal Link",
                 self.settings.app_name,
                 EndpointType.UDPServer,

--- a/core/services/ardupilot_manager/ArduPilotManager.py
+++ b/core/services/ardupilot_manager/ArduPilotManager.py
@@ -255,6 +255,15 @@ class ArduPilotManager(metaclass=Singleton):
                 persistent=True,
                 protected=True,
             ),
+            Endpoint(
+                "Internal Link",
+                self.settings.app_name,
+                EndpointType.UDPServer,
+                "127.0.0.1",
+                14001,
+                persistent=True,
+                protected=True,
+            ),
         ]
         for endpoint in default_endpoints:
             try:

--- a/core/start-companion-core
+++ b/core/start-companion-core
@@ -25,7 +25,7 @@ SERVICES=(
     'commander',"$SERVICES_PATH/commander/main.py"
     'nmea_injector',"$SERVICES_PATH/nmea_injector/main.py"
     'helper',"$SERVICES_PATH/helper/main.py"
-    'video',"mavlink-camera-manager --default-settings BlueROVUDP --verbose"
+    'video',"mavlink-camera-manager --default-settings BlueROVUDP  --mavlink udpout:127.0.0.1:14001 --verbose"
     'mavlink2rest',"mavlink2rest --connect=udpin:127.0.0.1:14000 --server 0.0.0.0:6040 --system-id $MAV_SYSTEM_ID --component-id $MAV_COMPONENT_ID_ONBOARD_COMPUTER4"
     'linux2rest',"linux2rest"
     'filebrowser',"filebrowser --database /etc/filebrowser/filebrowser.db --baseurl /file-browser"

--- a/core/start-companion-core
+++ b/core/start-companion-core
@@ -26,7 +26,7 @@ SERVICES=(
     'nmea_injector',"$SERVICES_PATH/nmea_injector/main.py"
     'helper',"$SERVICES_PATH/helper/main.py"
     'video',"mavlink-camera-manager --default-settings BlueROVUDP  --mavlink udpout:127.0.0.1:14001 --verbose"
-    'mavlink2rest',"mavlink2rest --connect=udpin:127.0.0.1:14000 --server 0.0.0.0:6040 --system-id $MAV_SYSTEM_ID --component-id $MAV_COMPONENT_ID_ONBOARD_COMPUTER4"
+    'mavlink2rest',"mavlink2rest --connect=udpout:127.0.0.1:14001 --server 0.0.0.0:6040 --system-id $MAV_SYSTEM_ID --component-id $MAV_COMPONENT_ID_ONBOARD_COMPUTER4"
     'linux2rest',"linux2rest"
     'filebrowser',"filebrowser --database /etc/filebrowser/filebrowser.db --baseurl /file-browser"
     'versionchooser',"$SERVICES_PATH/versionchooser/main.py"


### PR DESCRIPTION
so far, that means Mavlink2Rest and mavlink-camera-manager.
I'm not sure of how ArdupilotManager would handle changing an existing endpoint, so I made a new one...

williangalvani/companion-core:shared-link