### PR TITLE
Core: Tools: bump loviewer version to 0.9.8

### DIFF
--- a/core/tools/logviewer/bootstrap.sh
+++ b/core/tools/logviewer/bootstrap.sh
@@ -5,7 +5,7 @@ set -e
 
 DESTINATION_PATH="/home/pi/tools/logviewer"
 
-VERSION=v0.9.6
+VERSION=v0.9.8
 
 REMOTE_URL="https://github.com/Ardupilot/UAVLogViewer/releases/download/${VERSION}/logviewer.tar.gz"
 


### PR DESCRIPTION
allows using hidden field 'time_boot_ms' in expressions

Also improves plotting of messages with very low frequency,
which previously where not viewable

image ~building~ at williangalvani/companion-core:bumplogviewer