### PR TITLE
Bootstrap: check version-chooser in core and restart it if unresponsive

### DIFF
--- a/bootstrap/bootstrap/setup.py
+++ b/bootstrap/bootstrap/setup.py
@@ -7,5 +7,5 @@ setup(
     version="0.0.1",
     description="Blue Robotics Ardusub Companion Docker System Bootstrap",
     license="MIT",
-    install_requires=["docker == 5.0.0", "six == 1.15.0"],
+    install_requires=["docker == 5.0.0", "six == 1.15.0", "requests == 2.26.0"],
 )

--- a/bootstrap/test_bootstrap.py
+++ b/bootstrap/test_bootstrap.py
@@ -57,6 +57,9 @@ class FakeContainer:
     def remove(self) -> None:
         self.client.containers.remove(self.name)
 
+    def stop(self) -> None:
+        pass
+
 
 class FakeContainers:
     """Mocks "Containers" class from docker-py"""

--- a/install/install.sh
+++ b/install/install.sh
@@ -91,6 +91,7 @@ docker run \
     -t \
     --restart unless-stopped \
     --name companion-bootstrap \
+    --net=host \
     -v $HOME/.config/companion/bootstrap:/root/.config/bootstrap \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -e COMPANION_CONFIG_PATH=$HOME/.config/companion \


### PR DESCRIPTION
This add a new test in bootstrap to check if version-chooser is running properly in core.
after 60s of it being unresponsive, the startup.json file is restored and core is restarted from that.