### PR TITLE
Fix frontend settings

### DIFF
--- a/core/frontend/src/App.vue
+++ b/core/frontend/src/App.vue
@@ -13,7 +13,7 @@
         />
 
         <v-spacer />
-        <div 
+        <div
           v-if="settings.is_pirate_mode"
         >
           Ahoy matey! You're running

--- a/core/frontend/src/store/settings.ts
+++ b/core/frontend/src/store/settings.ts
@@ -4,6 +4,7 @@ import {
 } from 'vuex-module-decorators'
 
 import store from '@/store'
+import { castString } from '@/utils/helper_functions'
 
 @Module({
   dynamic: true,
@@ -46,7 +47,9 @@ class SettingsStore extends VuexModule {
      * @returns T
      */
     static loadVariable<T>(name: string): T {
-      return (window.localStorage.getItem(SettingsStore.settingsName(name)) as unknown) as T
+      const storedVariable = window.localStorage.getItem(SettingsStore.settingsName(name))
+      const castedVariable = storedVariable === null ? null : castString(storedVariable)
+      return castedVariable as T
     }
 
     /**

--- a/core/frontend/src/utils/helper_functions.ts
+++ b/core/frontend/src/utils/helper_functions.ts
@@ -16,3 +16,21 @@ export async function callPeriodically(func: () => Promise<void>, interval: numb
   await sleep(interval)
   callPeriodically(func, interval)
 }
+
+/* Cast a string into a proper javascript type. */
+/**
+ * @param value - String to be cast
+* */
+export function castString(value: string): any { // eslint-disable-line @typescript-eslint/no-explicit-any
+  if (typeof value !== 'string') {
+    return value
+  }
+
+  try {
+    return JSON.parse(value)
+  } catch (error) {
+    // If there's an error, assume it's just a string.
+  }
+
+  return value
+}

--- a/core/frontend/src/views/GeneralAutopilot.vue
+++ b/core/frontend/src/views/GeneralAutopilot.vue
@@ -42,8 +42,8 @@
 
 <script lang="ts">
 import Vue from 'vue'
-import settings from '@/libs/settings'
 
+import settings from '@/libs/settings'
 import autopilot from '@/store/autopilot_manager'
 import notifications from '@/store/notifications'
 import { Platform } from '@/types/autopilot'


### PR DESCRIPTION
As stated on #730, frontend settings were not working properly.

Basically what was happening was that the variables on the localStorage are always stored as a string or a null type. When loaded onto the vuex store, we were not casting those to proper types. With that, strange things were happening, like switches starting on true state even when a false state was comming from to localStorage. Problem was that the state was the string "false", which is true-ish on Javascript.

Added a `castString` helper function to help with that.
Some auto-fixes from the linter were also performed.

Fix #730 