### PR TITLE
core: version-chooser: Constrain dependency version

### DIFF
--- a/core/services/versionchooser/setup.py
+++ b/core/services/versionchooser/setup.py
@@ -46,6 +46,8 @@ setup(
         "aiohttp-jinja2 == 1.4.2",
         "aiohttp == 3.7.4",
         "aiodocker == 0.21.0",
+        "jsonschema == 3.2.0",
+        "pyrsistent == 0.16.0",
         "connexion[swagger-ui, aiohttp] == 2.7.0",
         "appdirs == 1.4.4",
         "pytest-asyncio == 0.14.0",


### PR DESCRIPTION
As stated [here](https://github.com/p1c2u/openapi-schema-validator/issues/31) version 0.2.0 of openapi-schema-validator introduces a dependency conflict with jsonschema.

As our dependency is connexion, we should follow [this](https://github.com/zalando/connexion/issues/1430) issue to be on track with changes.