### PR TITLE
Fix wifi unreadable

### DIFF
--- a/core/frontend/src/components/wifi/WifiManager.vue
+++ b/core/frontend/src/components/wifi/WifiManager.vue
@@ -112,10 +112,6 @@ export default Vue.extend({
       cursor: pointer;
   }
 
-  .available-network {
-      background-color: #f8f8f8;
-  }
-
   .available-network:hover {
       cursor: pointer;
       background-color: #c5c5c5;

--- a/core/frontend/src/components/wifi/WifiManager.vue
+++ b/core/frontend/src/components/wifi/WifiManager.vue
@@ -114,6 +114,6 @@ export default Vue.extend({
 
   .available-network:hover {
       cursor: pointer;
-      background-color: #c5c5c5;
+      background-color: #62b9e4;
   }
 </style>


### PR DESCRIPTION
- Custom color was impossible to read on dark mode, as seem on #734. Removing custom color and using default light theme is enough to fix the issue.
- Use a color that gets pretty both on light and dark mode for hovering available networks

![image](https://user-images.githubusercontent.com/6551040/150202329-546a73ce-7165-4502-882e-3e98f1749357.png)


Fix #734