### PR TITLE
core: version-chooser: fix filtering local docker images

### DIFF
--- a/core/services/versionchooser/utils/chooser.py
+++ b/core/services/versionchooser/utils/chooser.py
@@ -219,7 +219,7 @@ class VersionChooser:
         for image in await self.client.images.list():
             if not image["RepoTags"]:
                 continue
-            if not any(tag.startswith("companion-core:") for tag in image["RepoTags"]):
+            if not any("/companion-core:" in tag for tag in image["RepoTags"]):
                 continue
             for image_tag in image["RepoTags"]:
                 image_repository, tag = image_tag.split(":")


### PR DESCRIPTION
the fullname is something like "bluerobotics/companion-core:tagname", so startswith was always failing