### PR TITLE
Add option to skip board config during install

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -5,6 +5,42 @@ VERSION="${VERSION:-master}"
 REMOTE="${REMOTE:-https://raw.githubusercontent.com/bluerobotics/companion-docker}"
 ROOT="$REMOTE/$VERSION"
 
+# Additional options
+DO_BOARD_CONFIG=1 # default to do the board config
+
+usage_help()
+{
+    cat <<EOF
+BlueOS Installer
+Usage: install.sh [options]
+
+Options:
+    --help                  Show this help
+    --skip-board-config     Skip the board-specific configuration.
+                            Useful if you are not using Linux ArduPilot.
+EOF
+}
+
+get_options()
+{
+    while [[ $# -gt 0 ]]
+    do
+        opt="$1"
+        case $opt in 
+            --help)
+                usage_help
+                exit
+                ;;
+            --skip-board-config)
+                shift
+                DO_BOARD_CONFIG=0
+                shift
+                ;;
+        esac
+    done
+}
+get_options $*
+
 # Exit immediately if a command exits with a non-zero status
 set -e
 
@@ -32,8 +68,13 @@ curl -fsSL --silent $ROOT/install/install.sh 1> /dev/null || (
 )
 
 # Detect CPU and do necessary hardware configuration for each supported hardware
-echo "Starting hardware configuration."
-curl -fsSL "$ROOT/install/boards/configure_board.sh" | bash
+if [ $DO_BOARD_CONFIG -eq 1 ]
+then
+    echo "Starting hardware configuration."
+    curl -fsSL "$ROOT/install/boards/configure_board.sh" | bash
+else
+    echo "Skipping hardware configuration"
+fi
 
 echo "Checking for blocked wifi and bluetooth."
 rfkill unblock all


### PR DESCRIPTION
This addresses #736 by adding a `--skip-board-config` argument to the installation script. It also adds some rudimentary usage hints with the `--help` argument. The `get_options` function can easily be extended to accommodate future options (overriding git or docker image repos, for example).

This was tested on a Raspberry Pi 4 1GB running a clean install of `bullseye-lite` with the command:
```
sudo su -c 'curl -fsSL https://raw.githubusercontent.com/matt-bathyscope/companion-docker/master/install/install.sh | bash -s -- --skip-board-config'
```